### PR TITLE
Remove obsolete debug log

### DIFF
--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -160,13 +160,6 @@ export const sync = async (props: CLIOptions) => {
                 });
             }
 
-            console.log({
-                from,
-                to,
-                ...flags,
-                syncDirection,
-                test: "Test",
-            });
 
             if (syncDirection) {
                 if (isIt("all")) {


### PR DESCRIPTION
## Summary
- clean up `sync` command by removing console log with unused test value

## Testing
- `yarn test` *(fails: "This package doesn't seem to be present in your lockfile; run `yarn install` to update the lockfile")*