### PR TITLE
Fix datasource sync return and await usage

### DIFF
--- a/__tests__/cli-sync-datasources.test.ts
+++ b/__tests__/cli-sync-datasources.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const syncDatasources = vi.fn();
+const compare = vi.fn(({ local, external }) => ({ local, external }));
+const discoverDatasources = vi.fn();
+const discoverManyDatasources = vi.fn();
+
+vi.mock("../src/api/managementApi.js", () => ({
+    managementApi: {
+        datasources: {
+            syncDatasources,
+        },
+    },
+}));
+
+vi.mock("../src/cli/utils/discover.js", () => ({
+    compare,
+    discoverDatasources,
+    discoverManyDatasources,
+    LOOKUP_TYPE: {
+        fileName: "fileName",
+    },
+    SCOPE: {
+        local: "local",
+        external: "external",
+    },
+}));
+
+const { syncAllDatasources, syncProvidedDatasources } = await import(
+    "../src/cli/datasources/sync.js"
+);
+
+const tick = async () =>
+    new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+const createDeferred = () => {
+    let resolve!: () => void;
+
+    const promise = new Promise<void>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+
+    return { promise, resolve };
+};
+
+describe("Datasource sync CLI helpers", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        compare.mockImplementation(({ local, external }) => ({
+            local,
+            external,
+        }));
+        discoverDatasources.mockResolvedValue([]);
+        discoverManyDatasources.mockResolvedValue([]);
+    });
+
+    const expectSyncHelperToAwaitDatasourceSync = async (
+        syncHelper: () => Promise<void>,
+    ) => {
+        const deferred = createDeferred();
+        let helperResolved = false;
+
+        syncDatasources.mockImplementation(async () => {
+            await deferred.promise;
+        });
+
+        const helperPromise = syncHelper().then(() => {
+            helperResolved = true;
+        });
+
+        await tick();
+
+        expect(syncDatasources).toHaveBeenCalledTimes(1);
+        expect(helperResolved).toBe(false);
+
+        deferred.resolve();
+        await helperPromise;
+
+        expect(helperResolved).toBe(true);
+    };
+
+    it("awaits datasource sync for --all", async () => {
+        await expectSyncHelperToAwaitDatasourceSync(() =>
+            syncAllDatasources({} as any),
+        );
+    });
+
+    it("awaits datasource sync for provided datasource names", async () => {
+        await expectSyncHelperToAwaitDatasourceSync(() =>
+            syncProvidedDatasources({ datasources: ["colors"] }, {} as any),
+        );
+    });
+});

--- a/src/api/datasources/datasources.types.ts
+++ b/src/api/datasources/datasources.types.ts
@@ -23,8 +23,10 @@ export type SyncDatasources = (
 export type SyncProvidedDatasources = (
     args: { datasources: string[] },
     config: RequestBaseConfig,
-) => void;
-export type SyncAllDatasources = (config: RequestBaseConfig) => void;
+) => Promise<void>;
+export type SyncAllDatasources = (
+    config: RequestBaseConfig,
+) => Promise<void>;
 
 // Datasource Entries
 export type GetDatasourceEntries = (

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -130,14 +130,14 @@ export const sync = async (props: CLIOptions) => {
         case SYNC_COMMANDS.datasources:
             if (isIt("all")) {
                 Logger.log("Syncing all datasources with extension...");
-                syncAllDatasources(apiConfig);
+                await syncAllDatasources(apiConfig);
             }
 
             if (!flags["all"]) {
                 Logger.log("Syncing provided datasources with extension...");
                 const datasourcesToSync = unpackElements(input);
 
-                syncProvidedDatasources(
+                await syncProvidedDatasources(
                     { datasources: datasourcesToSync },
                     apiConfig,
                 );

--- a/src/cli/datasources/sync.ts
+++ b/src/cli/datasources/sync.ts
@@ -36,7 +36,7 @@ export const syncProvidedDatasources: SyncProvidedDatasources = async (
         external: allExternalDatasources,
     });
 
-    managementApi.datasources.syncDatasources(
+    await managementApi.datasources.syncDatasources(
         {
             providedDatasources: [...local, ...external],
         },
@@ -60,7 +60,7 @@ export const syncAllDatasources: SyncAllDatasources = async (config) => {
         external: allExternalDatasources,
     });
 
-    managementApi.datasources.syncDatasources(
+    await managementApi.datasources.syncDatasources(
         {
             providedDatasources: [...local, ...external],
         },


### PR DESCRIPTION
## Summary
- rebase the old datasource sync branch onto the current `beta`/`master` codebase (`v5.6.0`)
- keep the remaining useful part of the original change by making datasource CLI helpers return and await the datasource sync promise
- await datasource sync from the `sync datasources` command so the command promise reflects actual completion
- add focused regression coverage for the datasource sync helper await behavior

## Context
Most of the original API-layer refactor from this branch is already present in the current codebase through `src/api/datasources/datasources.sync.ts` and `syncDatasourcesData`. This PR carries forward the missing caller-side await behavior and updates the types/tests around it.

## Testing
- `npm run test:unit -- __tests__/cli-sync-datasources.test.ts`
- `npm run typecheck`