### PR TITLE
Improve migrate command 2

### DIFF
--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -13,6 +13,7 @@ import {
 import storyblokConfig from "../../config/config.js";
 import {
     createAndSaveToFile,
+    getFileContentWithRequire,
     getFilesContentWithRequire,
 } from "../../utils/files.js";
 import Logger from "../../utils/logger.js";
@@ -22,18 +23,41 @@ import { managementApi } from "../managementApi.js";
 
 export type MigrateFrom = "file" | "space";
 
+export interface PreparedMigrationConfig {
+    migrationConfigName: string;
+    migrationConfigFileContent: Record<string, MapperDefinition>;
+    componentsToMigrate: string[];
+}
+
+export interface MigrationStepReport {
+    migrationConfig: string;
+    touchedItems: number;
+    totalComponentReplacements: number;
+    replacementsByComponent: Record<string, number>;
+    maxDepth: number;
+}
+
+export interface MigrationPipelineResult {
+    changedItems: any[];
+    finalItems: any[];
+    stepReports: MigrationStepReport[];
+    totalItems: number;
+}
+
 interface MigrateItems {
     itemType: "story" | "preset";
     from: string;
     to: string;
     migrateFrom: MigrateFrom;
-    migrationConfig: string;
-    componentsToMigrate: string[];
+    migrationConfig: string | string[];
+    componentsToMigrate?: string[];
     filters?: {
         withSlug?: string[];
         startsWith?: string;
     };
     dryRun?: boolean;
+    fromFilePath?: string;
+    preparedMigrationConfigs?: PreparedMigrationConfig[];
 }
 
 interface ReplaceComponentData {
@@ -47,6 +71,20 @@ interface ReplaceComponentData {
 }
 
 export type MapperDefinition = (data: any) => any;
+
+export const normalizeMigrationConfigNames = (
+    migrationConfig: string | string[],
+): string[] => {
+    if (Array.isArray(migrationConfig)) {
+        return migrationConfig.filter((name) => Boolean(name));
+    }
+
+    if (typeof migrationConfig === "string" && migrationConfig.length > 0) {
+        return [migrationConfig];
+    }
+
+    return [];
+};
 
 function replaceComponentData({
     parent,
@@ -67,12 +105,12 @@ function replaceComponentData({
             parent[key]?.component &&
             components.includes(parent[key].component)
         ) {
-            const { ...rest } = parent[key];
             const { data: dataToReplace, wasReplaced } = (
                 mapper[parent[key].component] as MapperDefinition
             )(parent[key]);
 
-            parent[key] = { ...rest, ...dataToReplace };
+            // Keep migration output authoritative so key removals stay removed.
+            parent[key] = dataToReplace;
 
             if (storyblokConfig.debug) {
                 console.log(
@@ -104,8 +142,10 @@ function replaceComponentData({
                     ? sumOfReplacing[dataToReplace.component] + 1
                     : 1;
 
-                console.log("Sum of replacing: ");
-                console.log(sumOfReplacing);
+                if (storyblokConfig.debug) {
+                    console.log("Sum of replacing: ");
+                    console.log(sumOfReplacing);
+                }
             }
         }
 
@@ -141,15 +181,46 @@ function replaceComponentData({
     return currentMaxDepth;
 }
 
-export const prepareStoriesFromLocalFile = ({ from }: any) => {
-    // Get all stories to be migrated
+export const prepareStoriesFromLocalFile = ({
+    from,
+    fromFilePath,
+}: {
+    from?: string;
+    fromFilePath?: string;
+}) => {
+    if (fromFilePath) {
+        const resolvedFilePath = path.isAbsolute(fromFilePath)
+            ? fromFilePath
+            : path.resolve(process.cwd(), fromFilePath);
+
+        const fileContent = getFileContentWithRequire({
+            file: resolvedFilePath,
+        });
+
+        if (!fileContent) {
+            throw new Error(
+                `Couldn't receive data from provided stories path: ${chalk.red(
+                    fromFilePath,
+                )}`,
+            );
+        }
+
+        return fileContent;
+    }
+
+    if (!from) {
+        throw new Error(
+            "'from' is required for migrateFrom=file when fromFilePath is not provided.",
+        );
+    }
+
+    // Legacy discovery-based mode for story fixture names.
     const allLocalStories = discoverStories({
         scope: SCOPE.local,
         type: LOOKUP_TYPE.fileName,
         fileNames: [from],
     });
 
-    // Get content of all stories to be migrated
     const storiesFileContent = getFilesContentWithRequire({
         files: allLocalStories,
     })[0];
@@ -165,141 +236,156 @@ export const prepareStoriesFromLocalFile = ({ from }: any) => {
     return storiesFileContent;
 };
 
-export const prepareMigrationConfig = ({ migrationConfig }: any) => {
-    // Get migration config file with migration definition
-    const migrationConfigFiles = discoverMigrationConfig({
-        scope: SCOPE.local,
-        type: LOOKUP_TYPE.fileName,
-        fileNames: [migrationConfig],
-    });
+export const prepareMigrationConfigs = ({
+    migrationConfig,
+    componentsToMigrate,
+}: {
+    migrationConfig: string | string[];
+    componentsToMigrate?: string[];
+}): PreparedMigrationConfig[] => {
+    const migrationConfigNames = normalizeMigrationConfigNames(migrationConfig);
 
-    // Get content of migration config file
-    const migrationConfigFileContent = getFilesContentWithRequire({
-        files: migrationConfigFiles,
-    })[0];
-
-    if (isObjectEmpty(migrationConfigFileContent)) {
+    if (migrationConfigNames.length === 0) {
         throw new Error(
-            "Migration config file is empty. Please provide default exported config object with components map to migrate",
+            "Migration config is required. Pass at least one --migration value.",
         );
     }
 
-    if (!migrationConfigFileContent) {
-        throw new Error("Migration config probably doesnt exist. Create one");
-    }
+    const prepared: PreparedMigrationConfig[] = migrationConfigNames.map(
+        (migrationConfigName) => {
+            const migrationConfigFiles = discoverMigrationConfig({
+                scope: SCOPE.local,
+                type: LOOKUP_TYPE.fileName,
+                fileNames: [migrationConfigName],
+            });
+
+            const migrationConfigFileContent = getFilesContentWithRequire({
+                files: migrationConfigFiles,
+            })[0] as Record<string, MapperDefinition> | undefined;
+
+            if (isObjectEmpty(migrationConfigFileContent)) {
+                throw new Error(
+                    `Migration config file '${migrationConfigName}' is empty. Please provide default exported config object with components map to migrate`,
+                );
+            }
+
+            if (!migrationConfigFileContent) {
+                throw new Error(
+                    `Migration config '${migrationConfigName}' probably doesnt exist. Create one`,
+                );
+            }
+
+            const resolvedComponentsToMigrate =
+                componentsToMigrate && componentsToMigrate.length > 0
+                    ? componentsToMigrate
+                    : Object.keys(migrationConfigFileContent);
+
+            return {
+                migrationConfigName,
+                migrationConfigFileContent,
+                componentsToMigrate: resolvedComponentsToMigrate,
+            };
+        },
+    );
 
     Logger.success(`Migration config loaded.`);
 
-    return migrationConfigFileContent;
+    return prepared;
 };
 
-export const migrateAllComponentsDataInStories = async (
-    {
-        itemType,
-        migrationConfig,
-        migrateFrom,
-        from,
-        to,
-        filters,
-        dryRun,
-    }: Omit<MigrateItems, "componentsToMigrate">,
-    config: RequestBaseConfig,
-) => {
-    Logger.warning(
-        `Trying to migrate all ${itemType} from ${migrateFrom}, ${from} to ${to}...`,
-    );
+export const prepareMigrationConfig = ({
+    migrationConfig,
+}: {
+    migrationConfig: string;
+}) => {
+    const prepared = prepareMigrationConfigs({ migrationConfig });
+    const firstPrepared = prepared[0];
 
-    const migrationConfigFileContent = prepareMigrationConfig({
-        migrationConfig,
-    });
-
-    // Taking every component defined in const config = {} in migration config file
-    const componentsToMigrate = Object.keys(migrationConfigFileContent);
-
-    if (storyblokConfig.debug) {
-        Logger.warning(
-            "_________ Components in stories to migrate ___________",
-        );
-        console.log(componentsToMigrate);
+    if (!firstPrepared) {
+        throw new Error("Migration config is required.");
     }
 
-    await migrateProvidedComponentsDataInStories(
-        {
-            itemType,
-            migrationConfig,
-            migrateFrom,
-            from,
-            to,
-            componentsToMigrate,
-            filters,
-            dryRun,
-        },
-        config,
-    );
+    return firstPrepared.migrationConfigFileContent;
 };
 
-export const doTheMigration = async (
-    {
-        itemType = "story",
-        from,
-        itemsToMigrate,
-        componentsToMigrate,
-        migrationConfigFileContent,
-        migrationConfig,
-        to,
-        dryRun,
-    }: any,
-    config: RequestBaseConfig,
-) => {
+const deepClone = <T>(input: T): T => JSON.parse(JSON.stringify(input));
+
+const sumValues = (obj: Record<string, number>): number =>
+    Object.values(obj).reduce((sum, value) => sum + value, 0);
+
+const applySingleMigrationToItems = ({
+    itemType,
+    itemsToMigrate,
+    preparedMigrationConfig,
+}: {
+    itemType: "story" | "preset";
+    itemsToMigrate: any[];
+    preparedMigrationConfig: PreparedMigrationConfig;
+}): {
+    updatedItems: any[];
+    stepReport: MigrationStepReport;
+} => {
     const arrayOfMaxDepths: number[] = [];
-    const migratedItems = itemsToMigrate.map((item: any, index: number) => {
-        const sumOfReplacing: any = {};
+    const replacementsByComponent: Record<string, number> = {};
+
+    let touchedItems = 0;
+
+    const updatedItems = itemsToMigrate.map((item: any, index: number) => {
+        const sumOfReplacing: Record<string, number> = {};
 
         if (storyblokConfig.debug) {
             Logger.success(`#   ${index}   #`);
         }
 
         let json =
-            itemType === "story" ? item[itemType].content : item[itemType];
+            itemType === "story" ? item[itemType]?.content : item[itemType];
+
         const rootWrapper = { root: json };
 
         const maxDepth = replaceComponentData({
             parent: rootWrapper,
             key: "root",
-            components: componentsToMigrate,
-            mapper: migrationConfigFileContent,
+            components: preparedMigrationConfig.componentsToMigrate,
+            mapper: preparedMigrationConfig.migrationConfigFileContent,
             depth: 0,
             maxDepth: 0,
             sumOfReplacing,
         });
-        // After replacement, take potentially new root (root may be reassigned inside)
-        json = rootWrapper.root;
 
+        json = rootWrapper.root;
         arrayOfMaxDepths.push(maxDepth);
 
-        if (Object.keys(sumOfReplacing).length > 0) {
+        const didReplace = Object.keys(sumOfReplacing).length > 0;
+
+        if (didReplace) {
+            touchedItems += 1;
+            Object.entries(sumOfReplacing).forEach(([component, count]) => {
+                replacementsByComponent[component] =
+                    (replacementsByComponent[component] || 0) + count;
+            });
+
             console.log("  ");
             console.log(
                 `Migration in ${chalk.magenta(
                     itemType === "story"
-                        ? item[itemType].full_slug
-                        : item[itemType].name,
+                        ? item[itemType]?.full_slug
+                        : item[itemType]?.name,
                 )} page: `,
             );
-            componentsToMigrate.forEach((component: any) => {
-                if (sumOfReplacing[component]) {
-                    console.log(
-                        `${chalk.blue(
-                            component,
-                        )} component data was replaced: ${
-                            sumOfReplacing[component]
-                        } times.`,
-                    );
-                }
-            });
-        }
+            preparedMigrationConfig.componentsToMigrate.forEach(
+                (component: string) => {
+                    if (sumOfReplacing[component]) {
+                        console.log(
+                            `${chalk.blue(
+                                component,
+                            )} component data was replaced: ${
+                                sumOfReplacing[component]
+                            } times.`,
+                        );
+                    }
+                },
+            );
 
-        if (Object.keys(sumOfReplacing).length > 0) {
             return {
                 ...item,
                 [itemType]:
@@ -312,12 +398,13 @@ export const doTheMigration = async (
                               ...json,
                           },
             };
-        } else {
-            return null;
         }
+
+        return item;
     });
 
-    const maxDepth = Math.max(...arrayOfMaxDepths);
+    const maxDepth =
+        arrayOfMaxDepths.length > 0 ? Math.max(...arrayOfMaxDepths) : 0;
 
     if (storyblokConfig.debug) {
         console.log(" ");
@@ -329,24 +416,304 @@ export const doTheMigration = async (
         console.log(" ");
     }
 
-    const isListEmpty = (list: any[]) => list.filter((item) => item).length;
+    return {
+        updatedItems,
+        stepReport: {
+            migrationConfig: preparedMigrationConfig.migrationConfigName,
+            touchedItems,
+            maxDepth,
+            replacementsByComponent,
+            totalComponentReplacements: sumValues(replacementsByComponent),
+        },
+    };
+};
 
-    if (!isListEmpty(migratedItems)) {
-        console.log("# No Stories to update #");
-    } else {
-        console.log(`${migratedItems.length} stories to migrate`);
+export const runMigrationPipelineInMemory = ({
+    itemType,
+    itemsToMigrate,
+    preparedMigrationConfigs,
+}: {
+    itemType: "story" | "preset";
+    itemsToMigrate: any[];
+    preparedMigrationConfigs: PreparedMigrationConfig[];
+}): MigrationPipelineResult => {
+    const originalItems = deepClone(itemsToMigrate);
+    let workingItems = deepClone(itemsToMigrate);
+
+    const stepReports: MigrationStepReport[] = [];
+
+    preparedMigrationConfigs.forEach((preparedMigrationConfig) => {
+        const { updatedItems, stepReport } = applySingleMigrationToItems({
+            itemType,
+            itemsToMigrate: workingItems,
+            preparedMigrationConfig,
+        });
+
+        workingItems = updatedItems;
+        stepReports.push(stepReport);
+    });
+
+    const changedItems = workingItems.filter((item, index) => {
+        const originalItem = originalItems[index];
+
+        if (!originalItem) {
+            return true;
+        }
+
+        return JSON.stringify(item) !== JSON.stringify(originalItem);
+    });
+
+    return {
+        changedItems,
+        finalItems: workingItems,
+        stepReports,
+        totalItems: workingItems.length,
+    };
+};
+
+const savePipelineSummary = async (
+    {
+        from,
+        itemType,
+        dryRun,
+        migrateFrom,
+        fromFilePath,
+        pipelineResult,
+    }: {
+        from: string;
+        itemType: "story" | "preset";
+        dryRun?: boolean;
+        migrateFrom: MigrateFrom;
+        fromFilePath?: string;
+        pipelineResult: MigrationPipelineResult;
+    },
+    config: RequestBaseConfig,
+) => {
+    await createAndSaveToFile(
+        {
+            datestamp: true,
+            ext: "json",
+            filename: `${
+                dryRun ? "dry-run--" : ""
+            }${from}---${itemType}-migration-pipeline-summary`,
+            folder: "migrations",
+            res: {
+                itemType,
+                source: {
+                    migrateFrom,
+                    from,
+                    fromFilePath: fromFilePath || null,
+                },
+                totalItems: pipelineResult.totalItems,
+                totalChangedItems: pipelineResult.changedItems.length,
+                steps: pipelineResult.stepReports,
+            },
+        },
+        config,
+    );
+};
+
+const loadItemsToMigrate = async (
+    {
+        itemType,
+        migrateFrom,
+        from,
+        filters,
+        fromFilePath,
+    }: {
+        itemType: "story" | "preset";
+        migrateFrom: MigrateFrom;
+        from: string;
+        filters?: {
+            withSlug?: string[];
+            startsWith?: string;
+        };
+        fromFilePath?: string;
+    },
+    config: RequestBaseConfig,
+): Promise<any[]> => {
+    if (migrateFrom === "file") {
+        Logger.log("Migrating using file....");
+
+        const itemsFromFile = prepareStoriesFromLocalFile({
+            from,
+            fromFilePath,
+        });
+        const normalized = Array.isArray(itemsFromFile)
+            ? itemsFromFile
+            : [itemsFromFile];
+
+        if (itemType === "story") {
+            return normalized.filter(
+                (it: any) => !(it?.story?.is_folder === true),
+            );
+        }
+
+        return normalized;
     }
 
-    const notNullMigratedItems = migratedItems.filter((item: any) => item);
+    let itemsToMigrate: any[] = [];
 
-    // Saving result with migrated version of stories into file
+    if (itemType === "story") {
+        if (filters?.withSlug && filters.withSlug.length > 0) {
+            const results = await Promise.all(
+                filters.withSlug.map((slug) =>
+                    managementApi.stories.getStoryBySlug(slug, {
+                        ...config,
+                        spaceId: from,
+                    }),
+                ),
+            );
+            itemsToMigrate = (results.filter(Boolean) as any[]).filter(
+                (it: any) => !(it?.story?.is_folder === true),
+            );
+        } else if (filters?.startsWith) {
+            itemsToMigrate = await managementApi.stories.getAllStories(
+                { options: { starts_with: filters.startsWith } as any },
+                {
+                    ...config,
+                    spaceId: from,
+                },
+            );
+            itemsToMigrate = itemsToMigrate.filter(
+                (it: any) => !(it?.story?.is_folder === true),
+            );
+        } else {
+            itemsToMigrate = await managementApi.stories.getAllStories(
+                {},
+                {
+                    ...config,
+                    spaceId: from,
+                },
+            );
+            itemsToMigrate = itemsToMigrate.filter(
+                (it: any) => !(it?.story?.is_folder === true),
+            );
+        }
+
+        return itemsToMigrate;
+    }
+
+    return managementApi.presets.getAllPresets({
+        ...config,
+        spaceId: from,
+    });
+};
+
+export const migrateAllComponentsDataInStories = async (
+    {
+        itemType,
+        migrationConfig,
+        migrateFrom,
+        from,
+        to,
+        filters,
+        dryRun,
+        fromFilePath,
+    }: Omit<MigrateItems, "componentsToMigrate" | "preparedMigrationConfigs">,
+    config: RequestBaseConfig,
+) => {
+    Logger.warning(
+        `Trying to migrate all ${itemType} from ${migrateFrom}, ${from} to ${to}...`,
+    );
+
+    const preparedMigrationConfigs = prepareMigrationConfigs({
+        migrationConfig,
+    });
+
+    if (storyblokConfig.debug) {
+        Logger.warning(
+            "_________ Components in stories to migrate ___________",
+        );
+        console.log(
+            Array.from(
+                new Set(
+                    preparedMigrationConfigs.flatMap(
+                        (preparedMigrationConfig) =>
+                            preparedMigrationConfig.componentsToMigrate,
+                    ),
+                ),
+            ),
+        );
+    }
+
+    await migrateProvidedComponentsDataInStories(
+        {
+            itemType,
+            migrationConfig,
+            migrateFrom,
+            from,
+            to,
+            filters,
+            dryRun,
+            fromFilePath,
+            preparedMigrationConfigs,
+        },
+        config,
+    );
+};
+
+export const doTheMigration = async (
+    {
+        itemType = "story",
+        from,
+        itemsToMigrate,
+        migrationConfig,
+        migrationConfigs,
+        to,
+        dryRun,
+        migrateFrom,
+        fromFilePath,
+    }: {
+        itemType?: "story" | "preset";
+        from: string;
+        itemsToMigrate: any[];
+        migrationConfig?: string | string[];
+        migrationConfigs?: PreparedMigrationConfig[];
+        to: string;
+        dryRun?: boolean;
+        migrateFrom: MigrateFrom;
+        fromFilePath?: string;
+    },
+    config: RequestBaseConfig,
+) => {
+    const preparedMigrationConfigs =
+        migrationConfigs ||
+        prepareMigrationConfigs({
+            migrationConfig: migrationConfig || [],
+        });
+
+    const pipelineResult = runMigrationPipelineInMemory({
+        itemType,
+        itemsToMigrate,
+        preparedMigrationConfigs,
+    });
+
+    if (pipelineResult.changedItems.length === 0) {
+        console.log("# No Stories to update #");
+    } else {
+        console.log(`${pipelineResult.changedItems.length} stories to migrate`);
+    }
+
     await createAndSaveToFile(
         {
             datestamp: true,
             ext: "json",
             filename: `${dryRun ? "dry-run--" : ""}${from}---${itemType}-to-migrate`,
             folder: "migrations",
-            res: notNullMigratedItems,
+            res: pipelineResult.changedItems,
+        },
+        config,
+    );
+
+    await savePipelineSummary(
+        {
+            from,
+            itemType,
+            dryRun,
+            migrateFrom,
+            fromFilePath,
+            pipelineResult,
         },
         config,
     );
@@ -354,7 +721,7 @@ export const doTheMigration = async (
     if (dryRun) {
         console.log(" ");
         Logger.success(
-            `[DRY RUN] Migration preview complete. ${notNullMigratedItems.length} ${itemType}(s) would be affected.`,
+            `[DRY RUN] Migration preview complete. ${pipelineResult.changedItems.length} ${itemType}(s) would be affected.`,
         );
         Logger.success(
             `[DRY RUN] No API changes were made. Review the saved migration file for details.`,
@@ -362,12 +729,21 @@ export const doTheMigration = async (
         return;
     }
 
-    await modifyOrCreateAppliedMigrationsFile(migrationConfig, itemType);
+    for (const preparedMigrationConfig of preparedMigrationConfigs) {
+        await modifyOrCreateAppliedMigrationsFile(
+            preparedMigrationConfig.migrationConfigName,
+            itemType,
+        );
+    }
+
+    if (pipelineResult.changedItems.length === 0) {
+        return;
+    }
 
     if (itemType === "story") {
         await managementApi.stories.updateStories(
             {
-                stories: notNullMigratedItems,
+                stories: pipelineResult.changedItems,
                 spaceId: to,
                 options: { publish: false },
             },
@@ -376,7 +752,7 @@ export const doTheMigration = async (
     } else if (itemType === "preset") {
         await managementApi.presets.updatePresets(
             {
-                presets: notNullMigratedItems,
+                presets: pipelineResult.changedItems,
                 spaceId: to,
                 options: {},
             },
@@ -422,106 +798,61 @@ export const migrateProvidedComponentsDataInStories = async (
         componentsToMigrate,
         filters,
         dryRun,
+        fromFilePath,
+        preparedMigrationConfigs,
     }: MigrateItems,
     config: RequestBaseConfig,
 ) => {
-    const migrationConfigFileContent = prepareMigrationConfig({
-        migrationConfig,
-    });
+    const resolvedMigrationConfigs =
+        preparedMigrationConfigs ||
+        prepareMigrationConfigs({
+            migrationConfig,
+            componentsToMigrate,
+        });
 
-    if (migrateFrom === "file") {
-        Logger.log("Migrating using file....");
+    const itemsToMigrate = await loadItemsToMigrate(
+        {
+            itemType,
+            migrateFrom,
+            from,
+            filters,
+            fromFilePath,
+        },
+        config,
+    );
 
-        // Get all stories to be migrated from file
-        const itemsFromFile = prepareStoriesFromLocalFile({ from });
-        const itemsToMigrate = Array.isArray(itemsFromFile)
-            ? itemsFromFile.filter(
-                  (it: any) => !(it?.story?.is_folder === true),
-              )
-            : itemsFromFile;
-        await doTheMigration(
-            {
-                itemsToMigrate,
-                componentsToMigrate,
-                migrationConfigFileContent,
-                to,
-                dryRun,
-            },
-            config,
-        );
-    } else if (migrateFrom === "space") {
-        // Get all stories to be migrated from storyblok space
-        let itemsToMigrate: any[] = [];
-        if (itemType === "story") {
-            if (filters?.withSlug && filters.withSlug.length > 0) {
-                const results = await Promise.all(
-                    filters.withSlug.map((slug) =>
-                        managementApi.stories.getStoryBySlug(slug, {
-                            ...config,
-                            spaceId: from,
-                        }),
-                    ),
-                );
-                itemsToMigrate = (results.filter(Boolean) as any[]).filter(
-                    (it: any) => !(it?.story?.is_folder === true),
-                );
-            } else if (filters?.startsWith) {
-                itemsToMigrate = await managementApi.stories.getAllStories(
-                    { options: { starts_with: filters.startsWith } as any },
-                    {
-                        ...config,
-                        spaceId: from,
-                    },
-                );
-                itemsToMigrate = itemsToMigrate.filter(
-                    (it: any) => !(it?.story?.is_folder === true),
-                );
-            } else {
-                itemsToMigrate = await managementApi.stories.getAllStories(
-                    {},
-                    {
-                        ...config,
-                        spaceId: from,
-                    },
-                );
-                itemsToMigrate = itemsToMigrate.filter(
-                    (it: any) => !(it?.story?.is_folder === true),
-                );
-            }
-        } else if (itemType === "preset") {
-            itemsToMigrate = await managementApi.presets.getAllPresets({
-                ...config,
-                spaceId: from,
-            });
-        }
-
+    if (migrateFrom === "space" && !dryRun) {
         const backupFolder = path.join("backup", itemType);
+        const migrationLabel = resolvedMigrationConfigs
+            .map(
+                (preparedMigrationConfig) =>
+                    preparedMigrationConfig.migrationConfigName,
+            )
+            .join("__");
 
-        if (!dryRun) {
-            // save stories to file as backup
-            await saveBackupToFile(
-                {
-                    itemType,
-                    filename: `before__${migrationConfig}__${from}`,
-                    folder: backupFolder,
-                    res: itemsToMigrate,
-                },
-                config,
-            );
-        }
-
-        await doTheMigration(
+        await saveBackupToFile(
             {
                 itemType,
-                itemsToMigrate,
-                componentsToMigrate,
-                migrationConfigFileContent,
-                migrationConfig,
-                from,
-                to,
-                dryRun,
+                filename: `before__${migrationLabel}__${from}`,
+                folder: backupFolder,
+                res: itemsToMigrate,
             },
             config,
         );
     }
+
+    await doTheMigration(
+        {
+            itemType,
+            itemsToMigrate,
+            migrationConfigs: resolvedMigrationConfigs,
+            migrationConfig,
+            from,
+            to,
+            dryRun,
+            migrateFrom,
+            fromFilePath,
+        },
+        config,
+    );
 };

--- a/src/api/data-migration/migration-validation.ts
+++ b/src/api/data-migration/migration-validation.ts
@@ -1,0 +1,633 @@
+import { existsSync, readdirSync } from "fs";
+import path from "path";
+
+import { getFileContentWithRequire } from "../../utils/files.js";
+import Logger from "../../utils/logger.js";
+
+export type MigrationValidationIssue = {
+    componentPath: string;
+    component: string;
+    uid: string | null;
+    message: string;
+};
+
+type Observation = {
+    fields: Set<string>;
+    legacyItemBasis: string[];
+    legacyEmbedWidth: string[];
+    legacyEmbedHeight: string[];
+};
+
+export type ComponentRule = {
+    forbiddenFields?: string[];
+    requiredFields?: string[];
+    forbiddenTopLevelKeys?: string[];
+    requiredTopLevelKeys?: string[];
+    checkItemBasis?: boolean;
+    checkEmbedSizes?: boolean;
+};
+
+export type WrapperNormalizationRule = {
+    wrapperToBase: Record<string, string>;
+};
+
+export type RuleSetConfig = {
+    ruleSetName: string;
+    rules: Record<string, ComponentRule>;
+    noIssuesMessage: string;
+    wrapperNormalization?: WrapperNormalizationRule;
+};
+
+export type MigrationValidationDataFn = (args: {
+    data: unknown;
+    isDebug?: boolean;
+}) => MigrationValidationReport | Promise<MigrationValidationReport>;
+
+export type PreparedMigrationValidator = {
+    id: string;
+    name: string;
+    ruleSet?: RuleSetConfig;
+    validateData?: MigrationValidationDataFn;
+    sourcePath: string;
+};
+
+export type MigrationValidationReport = {
+    ok: boolean;
+    issueCount: number;
+    issues: MigrationValidationIssue[];
+};
+
+export class MigrationValidationFailedError extends Error {
+    migrationConfig: string;
+    validatorId: string;
+    validatorName: string;
+    issueCount: number;
+    issues: MigrationValidationIssue[];
+
+    constructor({
+        migrationConfig,
+        validatorId,
+        validatorName,
+        issueCount,
+        issues,
+    }: {
+        migrationConfig: string;
+        validatorId: string;
+        validatorName: string;
+        issueCount: number;
+        issues: MigrationValidationIssue[];
+    }) {
+        super(
+            `Validation failed for migration '${migrationConfig}' via '${validatorId}' (${issueCount} issue(s)).`,
+        );
+
+        this.name = "MigrationValidationFailedError";
+        this.migrationConfig = migrationConfig;
+        this.validatorId = validatorId;
+        this.validatorName = validatorName;
+        this.issueCount = issueCount;
+        this.issues = issues;
+    }
+}
+
+const maxFormatSamplesPerComponent = 3;
+
+const validationFileRegex = /\.validation\.(cjs|js|mjs)$/;
+
+const dedupe = <T>(items: T[]): T[] => Array.from(new Set(items));
+
+const debugLog = (isDebug: boolean, message: string) => {
+    if (isDebug) {
+        Logger.warning(`[VALIDATION] ${message}`);
+    }
+};
+
+const getObservation = (
+    observations: Map<string, Observation>,
+    key: string,
+): Observation => {
+    const existing = observations.get(key);
+    if (existing) return existing;
+
+    const created: Observation = {
+        fields: new Set<string>(),
+        legacyItemBasis: [],
+        legacyEmbedWidth: [],
+        legacyEmbedHeight: [],
+    };
+
+    observations.set(key, created);
+    return created;
+};
+
+const getKeySet = (map: Map<string, Set<string>>, key: string): Set<string> => {
+    const existing = map.get(key);
+    if (existing) return existing;
+
+    const created = new Set<string>();
+    map.set(key, created);
+    return created;
+};
+
+const formatPath = (pathParts: (string | number)[]): string => {
+    return pathParts
+        .map((segment, index) => {
+            if (typeof segment === "number") return `[${segment}]`;
+            if (index === 0) return segment;
+            return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(segment)
+                ? `.${segment}`
+                : `["${segment}"]`;
+        })
+        .join("");
+};
+
+const formatRelativePath = (pathParts: (string | number)[]): string =>
+    formatPath(pathParts);
+
+const pathKey = (pathParts: (string | number)[]): string => {
+    return pathParts
+        .map((segment) =>
+            typeof segment === "number" ? `n:${segment}` : `s:${segment}`,
+        )
+        .join("|");
+};
+
+const isLegacySizeValue = (value: unknown): boolean => {
+    if (value === null) return false;
+    if (typeof value === "string") return true;
+    if (typeof value === "number") return true;
+    if (typeof value === "boolean") return true;
+    if (typeof value !== "object") return false;
+
+    const maybeSize = value as { value?: unknown; unit?: unknown };
+    return !(
+        typeof maybeSize.value === "string" &&
+        typeof maybeSize.unit === "string"
+    );
+};
+
+const traverse = (
+    value: unknown,
+    visitor: (
+        currentValue: unknown,
+        key: string | number,
+        pathParts: (string | number)[],
+    ) => void,
+    pathParts: (string | number)[] = [],
+): void => {
+    if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+            const childPath = [...pathParts, i];
+            visitor(value[i], i, childPath);
+            traverse(value[i], visitor, childPath);
+        }
+        return;
+    }
+
+    if (value !== null && typeof value === "object") {
+        for (const key of Object.keys(value as Record<string, unknown>)) {
+            const childPath = [...pathParts, key];
+            const childValue = (value as Record<string, unknown>)[key];
+
+            visitor(childValue, key, childPath);
+            traverse(childValue, visitor, childPath);
+        }
+    }
+};
+
+const isRuleSetConfig = (value: unknown): value is RuleSetConfig => {
+    if (!value || typeof value !== "object") return false;
+
+    const maybe = value as {
+        ruleSetName?: unknown;
+        rules?: unknown;
+        noIssuesMessage?: unknown;
+    };
+
+    return (
+        typeof maybe.ruleSetName === "string" &&
+        Boolean(maybe.rules) &&
+        typeof maybe.rules === "object" &&
+        typeof maybe.noIssuesMessage === "string"
+    );
+};
+
+const toPreparedValidator = (
+    moduleValue: unknown,
+    sourcePath: string,
+): PreparedMigrationValidator | null => {
+    if (!moduleValue || typeof moduleValue !== "object") {
+        return null;
+    }
+
+    const maybe = moduleValue as {
+        id?: unknown;
+        name?: unknown;
+        ruleSet?: unknown;
+        validateData?: unknown;
+    };
+
+    if (typeof maybe.id !== "string" || typeof maybe.name !== "string") {
+        return null;
+    }
+
+    const ruleSet = isRuleSetConfig(maybe.ruleSet) ? maybe.ruleSet : undefined;
+    const validateData =
+        typeof maybe.validateData === "function"
+            ? (maybe.validateData as MigrationValidationDataFn)
+            : undefined;
+
+    if (!ruleSet && !validateData) {
+        return null;
+    }
+
+    return {
+        id: maybe.id,
+        name: maybe.name,
+        ruleSet,
+        validateData,
+        sourcePath,
+    };
+};
+
+const resolveValidatorPathCandidates = ({
+    migrationConfigName,
+    migrationConfigPath,
+}: {
+    migrationConfigName: string;
+    migrationConfigPath: string;
+}): string[] => {
+    const directReplaced = migrationConfigPath.replace(
+        /\.sb\.migration\.(cjs|js|mjs)$/,
+        ".validation.$1",
+    );
+
+    const migrationDir = path.dirname(migrationConfigPath);
+    const byNameInSameDir = [
+        path.join(migrationDir, `${migrationConfigName}.validation.cjs`),
+        path.join(migrationDir, `${migrationConfigName}.validation.js`),
+        path.join(migrationDir, `${migrationConfigName}.validation.mjs`),
+    ];
+
+    const discoveredInDir = readdirSync(migrationDir)
+        .filter((fileName) => validationFileRegex.test(fileName))
+        .map((fileName) => path.join(migrationDir, fileName));
+
+    return dedupe([
+        directReplaced,
+        ...byNameInSameDir,
+        ...discoveredInDir,
+    ]).filter((candidatePath) => existsSync(candidatePath));
+};
+
+export const discoverMigrationValidatorForMigrationFile = ({
+    migrationConfigName,
+    migrationConfigPath,
+}: {
+    migrationConfigName: string;
+    migrationConfigPath: string;
+}): PreparedMigrationValidator | null => {
+    const candidates = resolveValidatorPathCandidates({
+        migrationConfigName,
+        migrationConfigPath,
+    });
+
+    for (const candidatePath of candidates) {
+        try {
+            const loaded = getFileContentWithRequire({ file: candidatePath });
+            const prepared = toPreparedValidator(loaded, candidatePath);
+
+            if (prepared) {
+                return prepared;
+            }
+        } catch {
+            // ignore candidate and continue
+        }
+    }
+
+    return null;
+};
+
+export const validateRuleSetData = ({
+    data,
+    ruleSet,
+    isDebug = false,
+}: {
+    data: unknown;
+    ruleSet: RuleSetConfig;
+    isDebug?: boolean;
+}): MigrationValidationReport => {
+    const trackedFields = new Set(
+        Object.values(ruleSet.rules).flatMap((rule) => [
+            ...(rule.forbiddenFields ?? []),
+            ...(rule.requiredFields ?? []),
+        ]),
+    );
+
+    const hasItemBasisChecks = Object.values(ruleSet.rules).some(
+        (rule) => rule.checkItemBasis,
+    );
+    const hasEmbedSizeChecks = Object.values(ruleSet.rules).some(
+        (rule) => rule.checkEmbedSizes,
+    );
+
+    const targetComponents = new Set(Object.keys(ruleSet.rules));
+    const normalizedWrappers =
+        ruleSet.wrapperNormalization?.wrapperToBase ?? {};
+    const trackedWrapperComponents = new Set(Object.keys(normalizedWrappers));
+
+    const componentByPathKey = new Map<string, string>();
+    const pathByKey = new Map<string, (string | number)[]>();
+    const uidByPathKey = new Map<string, string>();
+    const observations = new Map<string, Observation>();
+    const objectKeysByPathKey = new Map<string, Set<string>>();
+
+    traverse(data, (value, key, pathParts) => {
+        if (typeof key === "string") {
+            const parentPath = pathParts.slice(0, -1);
+            const parentKey = pathKey(parentPath);
+            const keySet = getKeySet(objectKeysByPathKey, parentKey);
+            keySet.add(key);
+            pathByKey.set(parentKey, parentPath);
+        }
+
+        if (key === "component" && typeof value === "string") {
+            const componentPath = pathParts.slice(0, -1);
+            const keyStr = pathKey(componentPath);
+            componentByPathKey.set(keyStr, value);
+            pathByKey.set(keyStr, componentPath);
+
+            if (
+                targetComponents.has(value) ||
+                trackedWrapperComponents.has(value)
+            ) {
+                debugLog(
+                    isDebug,
+                    `found target component ${value} at ${formatPath(componentPath) || "(root)"}`,
+                );
+            }
+        }
+
+        if (key === "_uid" && typeof value === "string") {
+            const componentPath = pathParts.slice(0, -1);
+            const keyStr = pathKey(componentPath);
+            uidByPathKey.set(keyStr, value);
+            pathByKey.set(keyStr, componentPath);
+        }
+
+        const designIndex = pathParts.indexOf("design");
+        if (designIndex === -1) return;
+        if (pathParts[designIndex + 1] !== "fields") return;
+
+        const fieldName = pathParts[designIndex + 2];
+        if (typeof fieldName !== "string") return;
+
+        const componentPath = pathParts.slice(0, designIndex);
+        const keyStr = pathKey(componentPath);
+        pathByKey.set(keyStr, componentPath);
+        const observation = getObservation(observations, keyStr);
+
+        if (pathParts.length === designIndex + 3) {
+            observation.fields.add(fieldName);
+        }
+
+        if (
+            trackedFields.has(fieldName) &&
+            pathParts.length === designIndex + 3
+        ) {
+            debugLog(
+                isDebug,
+                `saw design.fields.${fieldName} at ${formatPath(pathParts.slice(0, designIndex + 3))}`,
+            );
+        }
+
+        if (pathParts[designIndex + 3] !== "values") return;
+        if (pathParts.length !== designIndex + 5) return;
+
+        const valuePath = formatRelativePath(pathParts.slice(designIndex + 3));
+
+        if (
+            hasItemBasisChecks &&
+            fieldName === "item_basis" &&
+            isLegacySizeValue(value)
+        ) {
+            if (
+                observation.legacyItemBasis.length <
+                maxFormatSamplesPerComponent
+            ) {
+                observation.legacyItemBasis.push(valuePath);
+            }
+        }
+
+        if (
+            hasEmbedSizeChecks &&
+            fieldName === "embed_width" &&
+            isLegacySizeValue(value)
+        ) {
+            if (
+                observation.legacyEmbedWidth.length <
+                maxFormatSamplesPerComponent
+            ) {
+                observation.legacyEmbedWidth.push(valuePath);
+            }
+        }
+
+        if (
+            hasEmbedSizeChecks &&
+            fieldName === "embed_height" &&
+            isLegacySizeValue(value)
+        ) {
+            if (
+                observation.legacyEmbedHeight.length <
+                maxFormatSamplesPerComponent
+            ) {
+                observation.legacyEmbedHeight.push(valuePath);
+            }
+        }
+    });
+
+    const issues: MigrationValidationIssue[] = [];
+
+    for (const [keyStr, component] of componentByPathKey.entries()) {
+        const componentPath = pathByKey.get(keyStr) ?? [];
+        const componentPathStr = formatPath(componentPath) || "(root)";
+        const uid = uidByPathKey.get(keyStr) ?? null;
+        const topLevelKeys =
+            objectKeysByPathKey.get(keyStr) ?? new Set<string>();
+        const observation =
+            observations.get(keyStr) ??
+            ({
+                fields: new Set<string>(),
+                legacyItemBasis: [],
+                legacyEmbedWidth: [],
+                legacyEmbedHeight: [],
+            } as Observation);
+
+        if (!ruleSet.rules[component] && !normalizedWrappers[component]) {
+            continue;
+        }
+
+        const rule = ruleSet.rules[component];
+
+        if (rule) {
+            for (const field of rule.forbiddenFields ?? []) {
+                if (observation.fields.has(field)) {
+                    issues.push({
+                        componentPath: componentPathStr,
+                        component,
+                        uid,
+                        message: `Forbidden field still present: design.fields.${field}`,
+                    });
+                }
+            }
+
+            for (const field of rule.requiredFields ?? []) {
+                if (!observation.fields.has(field)) {
+                    issues.push({
+                        componentPath: componentPathStr,
+                        component,
+                        uid,
+                        message: `Required field missing: design.fields.${field}`,
+                    });
+                }
+            }
+
+            for (const topLevelKey of rule.forbiddenTopLevelKeys ?? []) {
+                if (topLevelKeys.has(topLevelKey)) {
+                    issues.push({
+                        componentPath: componentPathStr,
+                        component,
+                        uid,
+                        message: `Forbidden top-level key still present: ${topLevelKey}`,
+                    });
+                }
+            }
+
+            for (const topLevelKey of rule.requiredTopLevelKeys ?? []) {
+                if (!topLevelKeys.has(topLevelKey)) {
+                    issues.push({
+                        componentPath: componentPathStr,
+                        component,
+                        uid,
+                        message: `Required top-level key missing: ${topLevelKey}`,
+                    });
+                }
+            }
+
+            if (rule.checkItemBasis && observation.legacyItemBasis.length > 0) {
+                issues.push({
+                    componentPath: componentPathStr,
+                    component,
+                    uid,
+                    message: `item_basis values still in V3 format (${observation.legacyItemBasis.join(", ")})`,
+                });
+            }
+
+            if (
+                rule.checkEmbedSizes &&
+                observation.legacyEmbedWidth.length > 0
+            ) {
+                issues.push({
+                    componentPath: componentPathStr,
+                    component,
+                    uid,
+                    message: `embed_width values still in V3 format (${observation.legacyEmbedWidth.join(", ")})`,
+                });
+            }
+
+            if (
+                rule.checkEmbedSizes &&
+                observation.legacyEmbedHeight.length > 0
+            ) {
+                issues.push({
+                    componentPath: componentPathStr,
+                    component,
+                    uid,
+                    message: `embed_height values still in V3 format (${observation.legacyEmbedHeight.join(", ")})`,
+                });
+            }
+        }
+
+        const expectedBaseComponent = normalizedWrappers[component];
+        if (expectedBaseComponent) {
+            issues.push({
+                componentPath: componentPathStr,
+                component,
+                uid,
+                message: `Wrapper component still present: component=${component} (expected ${expectedBaseComponent})`,
+            });
+        }
+    }
+
+    return {
+        ok: issues.length === 0,
+        issueCount: issues.length,
+        issues,
+    };
+};
+
+const isMigrationValidationReport = (
+    value: unknown,
+): value is MigrationValidationReport => {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    const maybe = value as {
+        ok?: unknown;
+        issueCount?: unknown;
+        issues?: unknown;
+    };
+
+    return (
+        typeof maybe.ok === "boolean" &&
+        typeof maybe.issueCount === "number" &&
+        Array.isArray(maybe.issues)
+    );
+};
+
+export const runPreparedMigrationValidator = ({
+    validator,
+    data,
+    isDebug = false,
+}: {
+    validator: PreparedMigrationValidator;
+    data: unknown;
+    isDebug?: boolean;
+}): MigrationValidationReport => {
+    if (validator.validateData) {
+        const result = validator.validateData({
+            data,
+            isDebug,
+        });
+
+        if (
+            result &&
+            typeof (result as PromiseLike<unknown>).then === "function"
+        ) {
+            throw new Error(
+                `Validator '${validator.id}' returned a Promise from validateData. sb-mig requires synchronous validateData for in-memory pipeline execution.`,
+            );
+        }
+
+        if (!isMigrationValidationReport(result)) {
+            throw new Error(
+                `Validator '${validator.id}' returned invalid report shape. Expected { ok, issueCount, issues[] }`,
+            );
+        }
+
+        return result;
+    }
+
+    if (validator.ruleSet) {
+        return validateRuleSetData({
+            data,
+            ruleSet: validator.ruleSet,
+            isDebug,
+        });
+    }
+
+    throw new Error(
+        `Validator '${validator.id}' has neither ruleSet nor validateData.`,
+    );
+};

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -95,12 +95,14 @@ export const migrateDescription = `
         --startsWith      - Filter stories by starts_with prefix
         --yes             - Skip ask for confirmation (dangerous, but useful in CI/CD)
         --dry-run         - Preview what would be migrated without making any API changes
+        --fileName        - Stable base name for migration output files (disables timestamp suffix for migration artifacts)
 
     EXAMPLES
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration migration-a --migration migration-b --migration migration-c
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --withSlug blog/home --withSlug docs/getting-started
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --startsWith blog/
+        $ sb-mig migrate content --all --from 12345 --to 12345 --migration v3toV4AllMigrations --dry-run --fileName brand-hub-v3-v4-run
         $ sb-mig migrate content --all --migrate-from file --from file-with-stories --to 12345 --migration file-with-migration
         $ sb-mig migrate content --all --migrate-from file --fromFilePath sbmig/migrations/dry-run--123---story-to-migrate__2026-2-9_20-51.json --to 12345 --migration migration-a --migration migration-b
         $ sb-mig migrate content my-component-1 my-component-2 --from 12345 --to 12345 --migration file-with-migration

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -76,6 +76,7 @@ export const copyDescription = `
 export const migrateDescription = `
     Usage
         $ sb-mig migrate [content] [space separated file names] or --all --from [spaceId] --to [spaceId] --migration [migration-config-filename]
+        $ sb-mig migrate content --all --migration migration-a --migration migration-b --migration migration-c
         
     Description
         Migrate content from space to space, or from file to space. It's potentially dangerous command, so it will ask for confirmation.
@@ -86,9 +87,10 @@ export const migrateDescription = `
      
     FLAGS
         --from            - Space ID from which you want to migrate / or file name if passed '--migrate-from file'
+        --fromFilePath    - Direct path to stories JSON file when using '--migrate-from file'
         --to              - Space ID to which you want to migrate
         --migrate-from    - Migrate from (space, file) default: space
-        --migration       - File name of migration file (without extension)
+        --migration       - File name of migration file (without extension). Can be repeated for ordered pipeline in content migration.
         --withSlug        - Filter stories by full slug (can be repeated)
         --startsWith      - Filter stories by starts_with prefix
         --yes             - Skip ask for confirmation (dangerous, but useful in CI/CD)
@@ -96,9 +98,11 @@ export const migrateDescription = `
 
     EXAMPLES
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration
+        $ sb-mig migrate content --all --from 12345 --to 12345 --migration migration-a --migration migration-b --migration migration-c
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --withSlug blog/home --withSlug docs/getting-started
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --startsWith blog/
         $ sb-mig migrate content --all --migrate-from file --from file-with-stories --to 12345 --migration file-with-migration
+        $ sb-mig migrate content --all --migrate-from file --fromFilePath sbmig/migrations/dry-run--123---story-to-migrate__2026-2-9_20-51.json --to 12345 --migration migration-a --migration migration-b
         $ sb-mig migrate content my-component-1 my-component-2 --from 12345 --to 12345 --migration file-with-migration
         $ sb-mig migrate content my-component-1 my-component-2 --migrate-from file --from file-with-stories --to 12345 --migration file-with-migration        
 `;

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -57,6 +57,7 @@ export const migrate = async (props: CLIOptions) => {
         "withSlug",
         "startsWith",
         "dryRun",
+        "fileName",
     ]);
 
     Logger.warning(
@@ -84,6 +85,7 @@ export const migrate = async (props: CLIOptions) => {
                 flags["migration"] as string | string[] | undefined,
             );
             const dryRun = flags["dryRun"] as boolean | undefined;
+            const fileName = flags["fileName"] as string | undefined;
             const withSlugFlag = flags["withSlug"] as
                 | string
                 | string[]
@@ -134,6 +136,7 @@ export const migrate = async (props: CLIOptions) => {
                             filters: { withSlug, startsWith },
                             dryRun,
                             fromFilePath,
+                            fileName,
                         },
                         apiConfig,
                     );
@@ -169,6 +172,7 @@ export const migrate = async (props: CLIOptions) => {
                             filters: { withSlug, startsWith },
                             dryRun,
                             fromFilePath,
+                            fileName,
                         },
                         apiConfig,
                     );
@@ -235,6 +239,7 @@ export const migrate = async (props: CLIOptions) => {
             if (isIt("all")) {
                 const migrateFrom: MigrateFrom = flags["migrateFrom"];
                 const dryRun = flags["dryRun"] as boolean | undefined;
+                const fileName = flags["fileName"] as string | undefined;
 
                 const runMigration = async () => {
                     Logger.warning("Preparing to migrate...");
@@ -263,6 +268,7 @@ export const migrate = async (props: CLIOptions) => {
                             migrationConfig: migrationConfigs[0] as string,
                             dryRun,
                             fromFilePath,
+                            fileName,
                         },
                         apiConfig,
                     );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -89,6 +89,9 @@ app.migrate = () => ({
                 type: "boolean",
                 default: false,
             },
+            fileName: {
+                type: "string",
+            },
         },
     }),
     action: (cli: any) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,6 +63,9 @@ app.migrate = () => ({
             from: {
                 type: "string",
             },
+            fromFilePath: {
+                type: "string",
+            },
             to: {
                 type: "string",
             },
@@ -70,6 +73,10 @@ app.migrate = () => ({
                 type: "string",
                 default: "space",
                 isRequired: true,
+            },
+            migration: {
+                type: "string",
+                isMultiple: true,
             },
             withSlug: {
                 type: "string",

--- a/storyblok.config.mjs
+++ b/storyblok.config.mjs
@@ -5,5 +5,5 @@ export default {
         "src/components",
         "src/storyblok",
     ],
-    rateLimit: 2,
+    rateLimit: 6,
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core content/preset migration flow, file loading, and artifact generation, and introduces multi-step execution with validation that can now abort migrations; incorrect configs/validators could block or alter migration outcomes.
> 
> **Overview**
> Enables running **ordered migration pipelines** by allowing repeated `--migration` flags; migrations are prepared as a list, applied sequentially in-memory, and only the items that actually changed are written/updated.
> 
> Adds an optional **co-located validation step** per migration (via new `*.validation.*` modules) that can enforce rule-based or custom checks after each step; failures stop the pipeline, print a short issue list, and save a detailed failure report artifact.
> 
> Improves migration IO/UX: supports `--fromFilePath` for direct JSON input when `--migrate-from file`, adds `--fileName` to produce stable artifact names (no timestamp), writes pipeline summaries plus extra dry-run before/after snapshots, adjusts backups to include all migration names, and makes migration output authoritative (no merging with prior component keys).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8661bc4572a8051a3796792ac3868ac2e99f8db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->