### PR TITLE
fix: prevent OOM in discover components

### DIFF
--- a/__tests__/utils/glob-utils.test.ts
+++ b/__tests__/utils/glob-utils.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { globSyncMock } = vi.hoisted(() => ({
+    globSyncMock: vi.fn((): string[] => []),
+}));
+
+vi.mock("glob", () => ({
+    globSync: globSyncMock,
+}));
+
+import {
+    NESTED_NODE_MODULES_PATTERN,
+    safeGlobSync,
+} from "../../src/utils/glob-utils.js";
+
+type CapturedOptions = {
+    follow?: boolean;
+    ignore?: string[] | string;
+};
+
+describe("safeGlobSync", () => {
+    const getFirstCall = (): [string, CapturedOptions] => {
+        expect(globSyncMock).toHaveBeenCalled();
+        return globSyncMock.mock.calls[0] as unknown as [string, CapturedOptions];
+    };
+
+    beforeEach(() => {
+        globSyncMock.mockReset();
+    });
+
+    it("enables follow by default and applies nested node_modules ignore", () => {
+        globSyncMock.mockReturnValue(["/tmp/component.sb.js"]);
+
+        const result = safeGlobSync("/tmp/**/[^_]*.sb.js");
+
+        expect(result).toEqual(["/tmp/component.sb.js"]);
+        expect(globSyncMock).toHaveBeenCalledTimes(1);
+
+        const [pattern, options] = getFirstCall();
+        expect(pattern).toBe("/tmp/**/[^_]*.sb.js");
+        expect(options).toMatchObject({
+            follow: true,
+            ignore: [NESTED_NODE_MODULES_PATTERN],
+        });
+    });
+
+    it("preserves explicit follow=false", () => {
+        safeGlobSync("/tmp/**/[^_]*.sb.js", { follow: false });
+
+        const [, options] = getFirstCall();
+        expect(options.follow).toBe(false);
+    });
+
+    it("merges existing ignore entries", () => {
+        safeGlobSync("/tmp/**/[^_]*.sb.js", {
+            ignore: ["**/dist/**"],
+        });
+
+        const [, options] = getFirstCall();
+        expect(options.ignore).toEqual([
+            "**/dist/**",
+            NESTED_NODE_MODULES_PATTERN,
+        ]);
+    });
+
+    it("normalizes string ignore to array", () => {
+        safeGlobSync("/tmp/**/[^_]*.sb.js", {
+            ignore: "**/.cache/**",
+        });
+
+        const [, options] = getFirstCall();
+        expect(options.ignore).toEqual([
+            "**/.cache/**",
+            NESTED_NODE_MODULES_PATTERN,
+        ]);
+    });
+});

--- a/src/cli/commands/discover.ts
+++ b/src/cli/commands/discover.ts
@@ -32,21 +32,25 @@ export const discover = async (props: CLIOptions) => {
                 );
 
                 const allComponents = await discoverAllComponents();
+                const content: string[] = [];
 
-                const content = [
-                    ...allComponents.local.map((component: any) =>
+                for (const component of allComponents.local) {
+                    content.push(
                         component.name
                             .replaceAll(".sb.js", "")
                             .replaceAll(".sb.cjs", "")
                             .replaceAll(".sb.mjs", ""),
-                    ),
-                    ...allComponents.external.map((component: any) =>
+                    );
+                }
+
+                for (const component of allComponents.external) {
+                    content.push(
                         component.name
                             .replaceAll(".sb.js", "")
                             .replaceAll(".sb.cjs", "")
                             .replaceAll(".sb.mjs", ""),
-                    ),
-                ];
+                    );
+                }
 
                 if (flags["write"]) {
                     await createAndSaveComponentListToFile(

--- a/src/cli/utils/discover.ts
+++ b/src/cli/utils/discover.ts
@@ -4,52 +4,10 @@
 
 import path from "path";
 
-// Support both ESM and CommonJS glob exports across versions
-import * as glob from "glob";
-type GlobSync = typeof glob.globSync;
-type GlobSyncOptions = {
-    follow?: boolean;
-    ignore?: string | string[];
-};
-
-const resolvedGlobSync =
-    (glob as unknown as { globSync?: GlobSync }).globSync ??
-    (glob as unknown as { sync?: GlobSync }).sync ??
-    (
-        glob as unknown as {
-            default?: { globSync?: GlobSync };
-        }
-    ).default?.globSync ??
-    (glob as unknown as { default?: { sync?: GlobSync } }).default?.sync;
-
-if (!resolvedGlobSync) {
-    throw new Error(
-        "Unable to resolve globSync from 'glob'. Please ensure a compatible glob version is installed.",
-    );
-}
-
-const NESTED_NODE_MODULES_PATTERN = "**/node_modules/**/node_modules/**";
-
-const globSync = (pattern: string, options?: GlobSyncOptions): string[] => {
-    const ignore = options?.ignore
-        ? Array.isArray(options.ignore)
-            ? options.ignore
-            : [options.ignore]
-        : [];
-
-    const result = resolvedGlobSync(pattern, {
-        ...options,
-        follow: options?.follow ?? true,
-        // Avoid traversing nested node_modules trees, which can explode memory usage.
-        ignore: [...ignore, NESTED_NODE_MODULES_PATTERN],
-    } as Parameters<GlobSync>[1]);
-
-    return result as string[];
-};
-
 import storyblokConfig, { SCHEMA } from "../../config/config.js";
 import { buildOnTheFly } from "../../rollup/build-on-the-fly.js";
 import { getFileContentWithRequire, readFile } from "../../utils/files.js";
+import { safeGlobSync as globSync } from "../../utils/glob-utils.js";
 import {
     normalizeDiscover,
     filesPattern,

--- a/src/cli/utils/discover.ts
+++ b/src/cli/utils/discover.ts
@@ -7,7 +7,12 @@ import path from "path";
 // Support both ESM and CommonJS glob exports across versions
 import * as glob from "glob";
 type GlobSync = typeof glob.globSync;
-const globSync =
+type GlobSyncOptions = {
+    follow?: boolean;
+    ignore?: string | string[];
+};
+
+const resolvedGlobSync =
     (glob as unknown as { globSync?: GlobSync }).globSync ??
     (glob as unknown as { sync?: GlobSync }).sync ??
     (
@@ -17,11 +22,30 @@ const globSync =
     ).default?.globSync ??
     (glob as unknown as { default?: { sync?: GlobSync } }).default?.sync;
 
-if (!globSync) {
+if (!resolvedGlobSync) {
     throw new Error(
         "Unable to resolve globSync from 'glob'. Please ensure a compatible glob version is installed.",
     );
 }
+
+const NESTED_NODE_MODULES_PATTERN = "**/node_modules/**/node_modules/**";
+
+const globSync = (pattern: string, options?: GlobSyncOptions): string[] => {
+    const ignore = options?.ignore
+        ? Array.isArray(options.ignore)
+            ? options.ignore
+            : [options.ignore]
+        : [];
+
+    const result = resolvedGlobSync(pattern, {
+        ...options,
+        follow: options?.follow ?? true,
+        // Avoid traversing nested node_modules trees, which can explode memory usage.
+        ignore: [...ignore, NESTED_NODE_MODULES_PATTERN],
+    } as Parameters<GlobSync>[1]);
+
+    return result as string[];
+};
 
 import storyblokConfig, { SCHEMA } from "../../config/config.js";
 import { buildOnTheFly } from "../../rollup/build-on-the-fly.js";

--- a/src/utils/glob-utils.ts
+++ b/src/utils/glob-utils.ts
@@ -1,0 +1,46 @@
+import * as glob from "glob";
+
+type GlobSync = typeof glob.globSync;
+
+export type GlobSyncOptions = {
+    follow?: boolean;
+    ignore?: string | string[];
+};
+
+const resolvedGlobSync =
+    (glob as unknown as { globSync?: GlobSync }).globSync ??
+    (glob as unknown as { sync?: GlobSync }).sync ??
+    (
+        glob as unknown as {
+            default?: { globSync?: GlobSync };
+        }
+    ).default?.globSync ??
+    (glob as unknown as { default?: { sync?: GlobSync } }).default?.sync;
+
+if (!resolvedGlobSync) {
+    throw new Error(
+        "Unable to resolve globSync from 'glob'. Please ensure a compatible glob version is installed.",
+    );
+}
+
+export const NESTED_NODE_MODULES_PATTERN = "**/node_modules/**/node_modules/**";
+
+export const safeGlobSync = (
+    pattern: string,
+    options?: GlobSyncOptions,
+): string[] => {
+    const ignore = options?.ignore
+        ? Array.isArray(options.ignore)
+            ? options.ignore
+            : [options.ignore]
+        : [];
+
+    const result = resolvedGlobSync(pattern, {
+        ...options,
+        follow: options?.follow ?? true,
+        // Avoid traversing nested node_modules trees, which can explode memory usage.
+        ignore: [...ignore, NESTED_NODE_MODULES_PATTERN],
+    } as Parameters<GlobSync>[1]);
+
+    return result as string[];
+};

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -143,20 +143,18 @@ export const filesPattern = ({
 export const compare = (request: CompareRequest): CompareResult => {
     const { local, external } = request;
 
-    const splittedLocal = local.map((p) => {
-        return {
-            name: p.split(path.sep)[p.split(path.sep).length - 1], // last element of split array - file name
-            p,
-        };
-    });
+    const splittedLocal = local.map((p) => ({
+        name: path.basename(p),
+        p,
+    }));
+
+    const localNames = new Set(splittedLocal.map((file) => file.name));
 
     const splittedExternal = external
-        .map((p) => {
-            return {
-                name: p.split(path.sep)[p.split(path.sep).length - 1], // last element of split array - file name
-                p,
-            };
-        })
+        .map((p) => ({
+            name: path.basename(p),
+            p,
+        }))
         .filter((file) => {
             // Filter out files from nested node_modules (node_modules within node_modules)
             const nodeModulesCount = (file.p.match(/node_modules/g) || [])
@@ -168,15 +166,7 @@ export const compare = (request: CompareRequest): CompareResult => {
     const result = {
         local: splittedLocal,
         external: splittedExternal.filter((externalComponent) => {
-            if (
-                splittedLocal.find(
-                    (localComponent) =>
-                        externalComponent.name === localComponent.name,
-                )
-            ) {
-                return false;
-            }
-            return true;
+            return !localNames.has(externalComponent.name);
         }),
     } as CompareResult;
 


### PR DESCRIPTION
## Summary
- add a glob wrapper in discover utils that ignores nested node_modules paths to avoid runaway scans and heap growth
- optimize local/external dedupe in compare() by using a Set instead of repeated linear lookups
- reduce temporary allocations when building discover component output for --write mode

## Verification
- npm run lint
- npm run typecheck
- npm run test -- __tests__/utils/path-utils.test.ts __tests__/utils/discover-compare.test.ts

## Issue
- Linear: MAR-689