### PR TITLE
fix: resolve fire-and-forget async bugs across CLI and API layers

### DIFF
--- a/src/api/datasources/datasource-entries.ts
+++ b/src/api/datasources/datasource-entries.ts
@@ -97,7 +97,7 @@ export const createDatasourceEntries: CreateDatasourceEntries = (
 ) => {
     const { datasource_entries, remoteDatasourceEntries, data } = args;
 
-    Promise.all(
+    return Promise.all(
         datasource_entries.map((datasourceEntry: any) => {
             const datasourceToBeUpdated =
                 remoteDatasourceEntries.datasource_entries.find(

--- a/src/api/migrate.ts
+++ b/src/api/migrate.ts
@@ -53,14 +53,14 @@ const _checkAndPrepareGroups: CheckAndPrepareGroups = async (
     const groupExist = (groupName: any) =>
         componentsGroups.find((group: any) => group.name === groupName);
 
-    groupsToCheck.forEach(async (groupName: string) => {
+    for (const groupName of groupsToCheck) {
         if (!groupExist(groupName)) {
             await managementApi.components.createComponentsGroup(
                 groupName,
                 config,
             );
         }
-    });
+    }
 };
 
 export const removeAllComponents = async (config: RequestBaseConfig) => {
@@ -100,7 +100,10 @@ export const removeSpecifiedComponents: RemoveSpecificComponents = async (
         componentsToRemove.length > 0 &&
         Promise.all(
             componentsToRemove.map((component: any) => {
-                managementApi.components.removeComponent(component, config);
+                return managementApi.components.removeComponent(
+                    component,
+                    config,
+                );
             }),
         )
     );
@@ -235,17 +238,19 @@ export const syncAssets: SyncAssets = async (
     Logger.log(`We would try to migrate Assets data from: ${from} to: ${to}`);
 
     const allAssets = await getAllAssets({ spaceId: from }, config);
-    allAssets.assets.map((asset) => {
-        const { id, created_at, updated_at, ...newAssetPayload } = asset;
-        migrateAsset(
-            {
-                migrateTo: to,
-                payload: newAssetPayload,
-                syncDirection,
-            },
-            config,
-        );
-    });
+    await Promise.all(
+        allAssets.assets.map((asset) => {
+            const { id, created_at, updated_at, ...newAssetPayload } = asset;
+            return migrateAsset(
+                {
+                    migrateTo: to,
+                    payload: newAssetPayload,
+                    syncDirection,
+                },
+                config,
+            );
+        }),
+    );
 };
 
 const syncStories: SyncStories = async (
@@ -411,7 +416,7 @@ export const setComponentDefaultPreset = async ({
         Logger.warning("Updating componet with default presets...");
         return Promise.all(
             finalRemoteComponents.map((component: any) => {
-                managementApi.components.updateComponent(
+                return managementApi.components.updateComponent(
                     component,
                     false,
                     apiConfig,

--- a/src/api/stories/tree.ts
+++ b/src/api/stories/tree.ts
@@ -34,9 +34,9 @@ const buildTree = (
     return tree;
 };
 
-export const traverseAndCreate: TraverseAndCreate = (input, config) => {
+export const traverseAndCreate: TraverseAndCreate = async (input, config) => {
     const { tree, realParentId, spaceId } = input;
-    tree.forEach(async (node) => {
+    for (const node of tree) {
         try {
             const { action, story } = node;
             const { parent, ...content } = story;
@@ -58,7 +58,7 @@ export const traverseAndCreate: TraverseAndCreate = (input, config) => {
             }
 
             if (node.children) {
-                traverseAndCreate(
+                await traverseAndCreate(
                     {
                         tree: node.children,
                         realParentId: storyId,
@@ -71,5 +71,5 @@ export const traverseAndCreate: TraverseAndCreate = (input, config) => {
             Logger.error("Error happened");
             Logger.error(e);
         }
-    });
+    }
 };

--- a/src/api/stories/tree.types.ts
+++ b/src/api/stories/tree.types.ts
@@ -18,4 +18,4 @@ export type TraverseAndCreate = (
         spaceId: string;
     },
     config: RequestBaseConfig,
-) => void;
+) => Promise<void>;

--- a/src/cli/commands/backup.ts
+++ b/src/cli/commands/backup.ts
@@ -92,7 +92,7 @@ export const backup = async (props: CLIOptions) => {
         case BACKUP_COMMANDS.stories:
             Logger.warning(`back up stories... with command: ${command}`);
             if (flags["all"]) {
-                backupStories(
+                await backupStories(
                     {
                         filename: "all-stories-backup",
                         suffix: ".stories",
@@ -326,30 +326,32 @@ export const backup = async (props: CLIOptions) => {
                     };
                 }
 
-                allRemoteComponents.forEach(async (component: any) => {
-                    managementApi.presets
-                        .getComponentPresets(component.name, apiConfig)
-                        .then(async (res: any) => {
-                            if (res) {
-                                await createAndSaveToFile(
-                                    {
-                                        ext: "json",
-                                        filename: `${component.name}.presets.sb`,
-                                        res: { allPresets: res, ...metadata },
-                                        folder: storyblokConfig.presetsBackupDirectory,
-                                    },
-                                    {
-                                        ...apiConfig,
-                                        sbmigWorkingDirectory: ".",
-                                    },
-                                );
-                            }
-                        })
-                        .catch((err: any) => {
-                            console.log(err);
-                            Logger.error("error happened... :(");
-                        });
-                });
+                for (const component of allRemoteComponents) {
+                    try {
+                        const res =
+                            await managementApi.presets.getComponentPresets(
+                                component.name,
+                                apiConfig,
+                            );
+                        if (res) {
+                            await createAndSaveToFile(
+                                {
+                                    ext: "json",
+                                    filename: `${component.name}.presets.sb`,
+                                    res: { allPresets: res, ...metadata },
+                                    folder: storyblokConfig.presetsBackupDirectory,
+                                },
+                                {
+                                    ...apiConfig,
+                                    sbmigWorkingDirectory: ".",
+                                },
+                            );
+                        }
+                    } catch (err: any) {
+                        console.log(err);
+                        Logger.error("error happened... :(");
+                    }
+                }
             }
             break;
         case BACKUP_COMMANDS.plugins:

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -33,7 +33,7 @@ export const remove = async (props: CLIOptions) => {
                 Logger.warning("Removing PROVIDED components...");
                 const componentToRemove = unpackElements(input);
 
-                removeSpecifiedComponents(
+                await removeSpecifiedComponents(
                     {
                         components: componentToRemove,
                     },

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -117,27 +117,27 @@ export const sync = async (props: CLIOptions) => {
             if (isIt("all")) {
                 Logger.log("Syncing all roles...");
 
-                syncAllRoles(apiConfig);
+                await syncAllRoles(apiConfig);
             }
 
             if (isIt("empty")) {
                 Logger.log("Syncing provided roles...");
                 const rolesToSync = unpackElements(input);
 
-                syncProvidedRoles({ roles: rolesToSync }, apiConfig);
+                await syncProvidedRoles({ roles: rolesToSync }, apiConfig);
             }
             break;
         case SYNC_COMMANDS.datasources:
             if (isIt("all")) {
                 Logger.log("Syncing all datasources with extension...");
-                syncAllDatasources(apiConfig);
+                await syncAllDatasources(apiConfig);
             }
 
             if (!flags["all"]) {
                 Logger.log("Syncing provided datasources with extension...");
                 const datasourcesToSync = unpackElements(input);
 
-                syncProvidedDatasources(
+                await syncProvidedDatasources(
                     { datasources: datasourcesToSync },
                     apiConfig,
                 );

--- a/src/cli/datasources/sync.ts
+++ b/src/cli/datasources/sync.ts
@@ -36,7 +36,7 @@ export const syncProvidedDatasources: SyncProvidedDatasources = async (
         external: allExternalDatasources,
     });
 
-    managementApi.datasources.syncDatasources(
+    await managementApi.datasources.syncDatasources(
         {
             providedDatasources: [...local, ...external],
         },
@@ -60,7 +60,7 @@ export const syncAllDatasources: SyncAllDatasources = async (config) => {
         external: allExternalDatasources,
     });
 
-    managementApi.datasources.syncDatasources(
+    await managementApi.datasources.syncDatasources(
         {
             providedDatasources: [...local, ...external],
         },

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -4,12 +4,12 @@ import chalk from "chalk";
 
 export const askForConfirmation = async (
     message: string,
-    resolveYes: () => void,
-    resolveNo: () => void,
+    resolveYes: () => void | Promise<void>,
+    resolveNo: () => void | Promise<void>,
     ci?: boolean,
 ) => {
     if (ci) {
-        resolveYes();
+        await resolveYes();
         return;
     }
     // This section has to be changed, it was fast solution to asking for confirmation
@@ -31,11 +31,11 @@ export const askForConfirmation = async (
     rl.prompt();
     for await (const deletionConfirmation of rl) {
         if (deletionConfirmation.trim() !== "y") {
-            resolveNo();
+            await resolveNo();
             process.exit(0);
         } else {
             if (deletionConfirmation) {
-                resolveYes();
+                await resolveYes();
 
                 break;
             }

--- a/src/cli/utils/discover.ts
+++ b/src/cli/utils/discover.ts
@@ -91,9 +91,9 @@ export const discoverManyByPackageName = (
             });
 
             listOfFiles = listOfPackagesJsonFiles
-                .filter(async (file) =>
+                .filter((file) =>
                     request.packageNames.includes(
-                        await getFileContentWithRequire({ file }).name,
+                        getFileContentWithRequire({ file }).name,
                     ),
                 ) // filter only package.json from provided request.packageNames
                 .map((file) => {


### PR DESCRIPTION
## Summary
- Replace `forEach(async)` with `for...of` in `traverseAndCreate`, `_checkAndPrepareGroups`, and preset backup — these were silently firing off async work without awaiting completion
- Add missing `return` in `.map()` callbacks for `removeSpecifiedComponents`, `setComponentDefaultPreset`, `syncAssets` — `Promise.all` was receiving `[undefined, ...]` and resolving instantly
- Add missing `return` before `Promise.all` in `createDatasourceEntries` — callers got `undefined` instead of the promise
- `await` async callbacks in `askForConfirmation` — fixes SSOT mode and content sync confirmation in CI (`--yes` flag)
- Add `await` to role sync, datasource sync, `removeSpecifiedComponents`, and `backupStories` CLI calls
- Remove spurious `async` from `.filter()` callback in `discoverManyByPackageName` — `Array.filter` doesn't handle async predicates, so every item was passing the filter

## Test plan
- [x] All 374 unit tests pass
- [x] TypeScript compiles with 0 errors
- [x] Lint-staged (prettier + eslint + tsc) passes
- [ ] Manual test: `sb-mig sync components --all` completes before CLI exits
- [ ] Manual test: `sb-mig backup component-presets --all` writes all files sequentially
- [ ] Manual test: `sb-mig sync components --all --ssot --yes` properly removes then syncs in CI mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)