### PR TITLE
Fix OOM crash in sync components --all

### DIFF
--- a/src/rollup/build-on-the-fly.ts
+++ b/src/rollup/build-on-the-fly.ts
@@ -27,38 +27,50 @@ export const buildOnTheFly = async ({ files }: BuildOnTheFly) => {
         `sb-mig`,
     );
 
-    await Promise.all(
-        files.map(async (filePath) => {
-            const inputOptions = {
-                input: filePath,
-                plugins: [
-                    ts({
-                        transpileOnly: true,
-                        transpiler: "swc",
-                    }),
-                ],
-            };
+    const BATCH_SIZE = 5;
+    const total = files.length;
 
-            const outputOptionsList = [
-                {
-                    file: path.join(
-                        `${cacheDir}`,
-                        `${_extractComponentName(filePath)}.cjs`,
-                    ),
-                    format: "cjs",
-                },
-                {
-                    file: path.join(
-                        `${cacheDir}`,
-                        `${_extractComponentName(filePath)}.js`,
-                    ),
-                    format: "es",
-                },
-            ];
+    Logger.log(`Compiling ${total} schema files...`);
 
-            await build({ inputOptions, outputOptionsList });
-        }),
-    );
+    for (let i = 0; i < total; i += BATCH_SIZE) {
+        const batch = files.slice(i, i + BATCH_SIZE);
+        const batchEnd = Math.min(i + BATCH_SIZE, total);
 
-    Logger.success("Precompile successfull!.");
+        Logger.log(`[${i + 1}-${batchEnd}/${total}] Compiling batch...`);
+
+        await Promise.all(
+            batch.map(async (filePath) => {
+                const inputOptions = {
+                    input: filePath,
+                    plugins: [
+                        ts({
+                            transpileOnly: true,
+                            transpiler: "swc",
+                        }),
+                    ],
+                };
+
+                const outputOptionsList = [
+                    {
+                        file: path.join(
+                            `${cacheDir}`,
+                            `${_extractComponentName(filePath)}.cjs`,
+                        ),
+                        format: "cjs",
+                    },
+                    {
+                        file: path.join(
+                            `${cacheDir}`,
+                            `${_extractComponentName(filePath)}.js`,
+                        ),
+                        format: "es",
+                    },
+                ];
+
+                await build({ inputOptions, outputOptionsList });
+            }),
+        );
+    }
+
+    Logger.success(`Precompile successful! (${total} files)`);
 };

--- a/src/rollup/setup-rollup.ts
+++ b/src/rollup/setup-rollup.ts
@@ -16,20 +16,18 @@ interface Build {
 
 export async function build({ inputOptions, outputOptionsList }: Build) {
     let bundle;
-    let buildFailed = false;
     try {
         bundle = await rollup(inputOptions);
-
         await generateOutputs({ bundle, outputOptionsList });
         return [];
     } catch (error) {
-        buildFailed = true;
         console.error(error);
+        throw error;
+    } finally {
+        if (bundle) {
+            await bundle.close();
+        }
     }
-    if (bundle) {
-        await bundle.close();
-    }
-    process.exit(buildFailed ? 1 : 0);
 }
 
 interface GenerateOutputs {


### PR DESCRIPTION
## Summary
- **Fixed Rollup bundle memory leak**: `bundle.close()` was never called on successful builds due to early `return` before the cleanup code. With ~76 concurrent builds, this leaked all Rollup instances (module graphs, ASTs, SWC transpiler state) causing heap OOM at ~4GB. Fixed with `try/finally`.
- **Batched parallel builds**: Changed from `Promise.all` over all files to batches of 5, preventing memory spikes from 76 simultaneous Rollup+SWC instances.
- **Added progress logging**: Batch progress (`[1-5/76] Compiling batch...`) so users can see what's happening during long syncs.
- **Removed `process.exit()` in build function**: Now throws the error instead of killing the process.

## Test plan
- [x] Tested `sb-mig sync components --all` on a project with 76 `.sb.ts` schemas — previously OOM'd at 4GB, now completes successfully (222 components synced, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)