### PR TITLE
fix: resolve migration discovery in mixed directories

### DIFF
--- a/__tests__/discover.test.ts
+++ b/__tests__/discover.test.ts
@@ -2,7 +2,11 @@ import path from "path";
 
 import { describe, it, expect } from "vitest";
 
-import { filesPattern, normalizeDiscover } from "../src/utils/path-utils.js";
+import {
+    exactFilesPatterns,
+    filesPattern,
+    normalizeDiscover,
+} from "../src/utils/path-utils.js";
 
 describe("Discovering files", () => {
     it("pattern passed to glob work correctly for sb.ts extension for unix paths", () => {
@@ -65,5 +69,38 @@ describe("Discovering files", () => {
         });
 
         expect(normalized).toBe("");
+    });
+
+    it("exactFilesPatterns preserves relative node_modules directories", () => {
+        if (process.platform === "win32") return expect(true).toBe(true);
+
+        const directory = path.join(
+            "Users",
+            "someone",
+            "Projects",
+            "digital-experience-web",
+            "apps",
+            "web",
+        );
+        const componentDirectories = [
+            "src/components",
+            "src/storyblok",
+            "../../node_modules/@ef-global",
+            "./node_modules/@ef-global",
+        ];
+
+        const patterns = exactFilesPatterns({
+            mainDirectory: directory,
+            componentDirectories,
+            fileNames: ["itemsToContent"],
+            ext: "sb.migration.cjs",
+        }).map((pattern) => pattern.replace(/\\/g, "/"));
+
+        expect(patterns).toEqual([
+            "Users/someone/Projects/digital-experience-web/apps/web/src/components/**/itemsToContent.sb.migration.cjs",
+            "Users/someone/Projects/digital-experience-web/apps/web/src/storyblok/**/itemsToContent.sb.migration.cjs",
+            "Users/someone/Projects/digital-experience-web/node_modules/@ef-global/**/itemsToContent.sb.migration.cjs",
+            "Users/someone/Projects/digital-experience-web/apps/web/node_modules/@ef-global/**/itemsToContent.sb.migration.cjs",
+        ]);
     });
 });

--- a/src/cli/utils/discover.ts
+++ b/src/cli/utils/discover.ts
@@ -11,6 +11,7 @@ import { safeGlobSync as globSync } from "../../utils/glob-utils.js";
 import {
     normalizeDiscover,
     filesPattern,
+    exactFilesPatterns,
     compare,
     type CompareResult,
     type OneFileElement,
@@ -59,6 +60,7 @@ export {
     normalizeDiscover,
     compare,
     filesPattern,
+    exactFilesPatterns,
 } from "../../utils/path-utils.js";
 
 export const discoverManyByPackageName = (
@@ -668,30 +670,20 @@ export const discoverMigrationConfig = (
 ): DiscoverResult => {
     const rootDirectory = "./";
     const directory = path.resolve(process.cwd(), rootDirectory);
-    let pattern;
-    let listOfFiles = [""];
+    let listOfFiles: string[] = [];
 
     switch (request.scope) {
         case SCOPE.local:
-            // ### MANY - LOCAL - fileName ###
-            // const onlyLocalComponentsDirectories =
-            //     storyblokConfig.componentsDirectories.filter(
-            //         (p: string) => !p.includes("node_modules")
-            //     );
-            pattern = path.join(
-                `${directory}`,
-                `${normalizeDiscover({
-                    segments: storyblokConfig.componentsDirectories,
-                })}`,
-                "**",
-                `${normalizeDiscover({ segments: request.fileNames })}.${
-                    storyblokConfig.migrationConfigExt
-                }`,
+            listOfFiles = exactFilesPatterns({
+                mainDirectory: directory,
+                componentDirectories: storyblokConfig.componentsDirectories,
+                fileNames: request.fileNames,
+                ext: storyblokConfig.migrationConfigExt,
+            }).flatMap((pattern) =>
+                globSync(pattern.replace(/\\/g, "/"), {
+                    follow: true,
+                }),
             );
-
-            listOfFiles = globSync(pattern.replace(/\\/g, "/"), {
-                follow: true,
-            });
 
             break;
 
@@ -776,25 +768,20 @@ export const discoverVersionMapping = (
 ): DiscoverResult => {
     const rootDirectory = "./";
     const directory = path.resolve(process.cwd(), rootDirectory);
-    let pattern;
-    let listOfFiles = [""];
+    let listOfFiles: string[] = [];
 
     switch (request.scope) {
         case SCOPE.all:
-            pattern = path.join(
-                `${directory}`,
-                `${normalizeDiscover({
-                    segments: storyblokConfig.componentsDirectories,
-                })}`,
-                "**",
-                `${normalizeDiscover({
-                    segments: request.fileNames,
-                })}.${"sb.migrations.cjs"}`,
+            listOfFiles = exactFilesPatterns({
+                mainDirectory: directory,
+                componentDirectories: storyblokConfig.componentsDirectories,
+                fileNames: request.fileNames,
+                ext: "sb.migrations.cjs",
+            }).flatMap((pattern) =>
+                globSync(pattern.replace(/\\/g, "/"), {
+                    follow: true,
+                }),
             );
-
-            listOfFiles = globSync(pattern.replace(/\\/g, "/"), {
-                follow: true,
-            });
 
             break;
 

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -123,6 +123,34 @@ export const filesPattern = ({
 };
 
 /**
+ * Builds glob file patterns for discovering exact file names across directories.
+ * Uses one pattern per directory/name pair so relative paths like ../../node_modules
+ * are preserved and not corrupted by path.join on brace-expanded segments.
+ */
+export const exactFilesPatterns = ({
+    mainDirectory,
+    componentDirectories,
+    fileNames,
+    ext,
+}: {
+    mainDirectory: string;
+    componentDirectories: string[];
+    fileNames: string[];
+    ext: string;
+}): string[] => {
+    return componentDirectories.flatMap((componentDirectory) =>
+        fileNames.map((fileName) =>
+            path.join(
+                `${mainDirectory}`,
+                `${componentDirectory}`,
+                "**",
+                `${fileName}.${ext}`,
+            ),
+        ),
+    );
+};
+
+/**
  * Compares local and external file path arrays.
  * Splits paths to extract file names, filters out duplicates from external
  * (preferring local files), and filters out nested node_modules.


### PR DESCRIPTION
## Summary
- fix exact-name migration discovery when `componentsDirectories` mixes local paths with `../../node_modules` entries
- switch migration and `versionMapping` lookup to generate one glob per directory instead of using a single brace-expanded path
- add a regression test covering the digital-experience-web style directory layout

## Validation
- `npm run test:unit -- __tests__/discover.test.ts`
- `npm run typecheck`
- `npm run build`

## Notes
- left the existing unrelated `package-lock.json` modification out of this PR