### PR TITLE
feat: support extending migration component scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,49 @@ This command will look for `row.sb.js` and `column.sb.js` files inside a directo
 
 ## Syncing datasources
 
+## Migrating content
+
+Use `sb-mig migrate content` to run one or more migration configs against
+stories from a space or from a file.
+
+```bash
+sb-mig migrate content --all --from 12345 --to 12345 --migration itemsToContent
+```
+
+### Extending migration component scope
+
+Migration files export a mapper keyed by component name. By default, `sb-mig`
+runs a migration only for the component keys exported by that migration file.
+
+Use these flags when a consuming app has wrapper components that should reuse an
+existing migration function:
+
+- `--migrationComponentAlias`
+  Format: `<migration>:<source>=<alias1>,<alias2>`
+- `--migrationComponents`
+  Format: `<migration>:<component1>,<component2>`
+
+`--migrationComponentAlias` extends the migration mapper at runtime by reusing
+the source component's migration function for extra component names.
+
+`--migrationComponents` overrides the exact component scope for that migration.
+
+Example:
+
+```bash
+sb-mig migrate content --all \
+  --from 12345 \
+  --to 12345 \
+  --migration colorPickerModeValues \
+  --migrationComponentAlias colorPickerModeValues:sb-button=sb-open-drift-button \
+  --migrationComponentAlias colorPickerModeValues:sb-section=sb-tour-page-section \
+  --migrationComponents colorPickerModeValues:sb-button,sb-open-drift-button,sb-section,sb-tour-page-section
+```
+
+This runs `colorPickerModeValues` for the normal Backpack keys and also for the
+two wrapper component names by aliasing them onto the existing `sb-button` and
+`sb-section` migration handlers.
+
 You can also sync your `datasources`.
 
 Add `datasourceExt: "your-own-extension",` to your `storyblok.config.js`. If u will not add it, will be used default one (`sb.datasource.js`)

--- a/__tests__/api/file-naming.test.ts
+++ b/__tests__/api/file-naming.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildPreMigrationBackupBaseName,
+    buildStoryBackupBaseName,
+    resolveOutputFileBaseName,
+} from "../../src/api/data-migration/file-naming.js";
+
+describe("migration file naming", () => {
+    it("uses the provided fileName as the stable artifact base name", () => {
+        expect(
+            resolveOutputFileBaseName({
+                from: "291250444542472",
+                fileName: "test migration run",
+            }),
+        ).toBe("test-migration-run");
+    });
+
+    it("sanitizes fallback names derived from the source identifier", () => {
+        expect(
+            resolveOutputFileBaseName({
+                from: "space/291250444542472",
+            }),
+        ).toBe("space-291250444542472");
+    });
+
+    it("builds a short pre-migration backup base name", () => {
+        expect(
+            buildPreMigrationBackupBaseName({
+                from: "291250444542472",
+            }),
+        ).toBe("before__291250444542472");
+    });
+
+    it("builds a short story backup base name", () => {
+        expect(
+            buildStoryBackupBaseName({
+                from: "291250444542472",
+                fileName: "all",
+            }),
+        ).toBe("all--backup-before-migration");
+    });
+});

--- a/__tests__/api/migration-component-scope.test.ts
+++ b/__tests__/api/migration-component-scope.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    extendMigrationMapperWithAliases,
+    parseMigrationComponentAliasFlags,
+    parseMigrationComponentOverrideFlags,
+    resolveMigrationComponentsToMigrate,
+} from "../../src/api/data-migration/migration-component-scope.js";
+
+describe("migration component scope", () => {
+    it("parses repeatable alias flags", () => {
+        expect(
+            parseMigrationComponentAliasFlags([
+                "colorPickerModeValues:sb-button=sb-open-drift-button",
+                "colorPickerModeValues:sb-section=sb-tour-page-section,sb-tour-page-hero",
+            ]),
+        ).toEqual({
+            colorPickerModeValues: {
+                "sb-button": ["sb-open-drift-button"],
+                "sb-section": [
+                    "sb-tour-page-section",
+                    "sb-tour-page-hero",
+                ],
+            },
+        });
+    });
+
+    it("parses per-migration component overrides", () => {
+        expect(
+            parseMigrationComponentOverrideFlags([
+                "colorPickerModeValues:sb-button,sb-open-drift-button",
+            ]),
+        ).toEqual({
+            colorPickerModeValues: ["sb-button", "sb-open-drift-button"],
+        });
+    });
+
+    it("extends a mapper with alias component names", () => {
+        const mapper = {
+            "sb-button": (data: unknown) => data,
+        };
+
+        const extended = extendMigrationMapperWithAliases(mapper, {
+            "sb-button": ["sb-open-drift-button"],
+        });
+
+        expect(extended["sb-button"]).toBe(mapper["sb-button"]);
+        expect(extended["sb-open-drift-button"]).toBe(mapper["sb-button"]);
+    });
+
+    it("prefers per-migration overrides over the mapper key list", () => {
+        const mapper = {
+            "sb-button": (data: unknown) => data,
+            "sb-open-drift-button": (data: unknown) => data,
+        };
+
+        expect(
+            resolveMigrationComponentsToMigrate({
+                mapper,
+                migrationName: "colorPickerModeValues",
+                perMigrationOverrides: {
+                    colorPickerModeValues: [
+                        "sb-button",
+                        "sb-open-drift-button",
+                    ],
+                },
+            }),
+        ).toEqual(["sb-button", "sb-open-drift-button"]);
+    });
+
+    it("throws when an override references an unknown component", () => {
+        expect(() =>
+            resolveMigrationComponentsToMigrate({
+                mapper: {
+                    "sb-button": (data: unknown) => data,
+                },
+                migrationName: "colorPickerModeValues",
+                perMigrationOverrides: {
+                    colorPickerModeValues: ["sb-open-drift-button"],
+                },
+            }),
+        ).toThrow(/unknown components/);
+    });
+});

--- a/__tests__/api/write-summary.test.ts
+++ b/__tests__/api/write-summary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeMutationWriteResults } from "../../src/api/data-migration/write-summary.js";
+
+describe("summarizeMutationWriteResults", () => {
+    it("counts successful and failed fulfilled results", () => {
+        const summary = summarizeMutationWriteResults([
+            {
+                status: "fulfilled",
+                value: { ok: true, slug: "good-story" },
+            },
+            {
+                status: "fulfilled",
+                value: {
+                    ok: false,
+                    slug: "bad-story",
+                    error: new Error("Unprocessable Content"),
+                },
+            },
+        ]);
+
+        expect(summary).toMatchObject({
+            total: 2,
+            successful: 1,
+            failed: 1,
+        });
+        expect(summary.failedItems[0]?.slug).toBe("bad-story");
+    });
+
+    it("treats rejected results as failures", () => {
+        const summary = summarizeMutationWriteResults([
+            {
+                status: "rejected",
+                reason: new Error("network error"),
+            },
+        ]);
+
+        expect(summary).toMatchObject({
+            total: 1,
+            successful: 0,
+            failed: 1,
+        });
+        expect(summary.failedItems[0]?.ok).toBe(false);
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sb-mig",
-  "version": "5.6.0-beta.4",
+  "version": "5.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sb-mig",
-      "version": "5.6.0-beta.4",
+      "version": "5.6.1",
       "license": "MIT",
       "dependencies": {
         "@swc/core": "1.3.41",

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -27,6 +27,12 @@ import {
     shouldUseDatestampForArtifacts,
 } from "./file-naming.js";
 import {
+    extendMigrationMapperWithAliases,
+    type MigrationComponentAliasesByMigration,
+    type MigrationComponentOverridesByMigration,
+    resolveMigrationComponentsToMigrate,
+} from "./migration-component-scope.js";
+import {
     discoverMigrationValidatorForMigrationFile,
     MigrationValidationFailedError,
     runPreparedMigrationValidator,
@@ -75,6 +81,8 @@ interface MigrateItems {
     migrateFrom: MigrateFrom;
     migrationConfig: string | string[];
     componentsToMigrate?: string[];
+    migrationComponentAliases?: MigrationComponentAliasesByMigration;
+    migrationComponentOverrides?: MigrationComponentOverridesByMigration;
     filters?: {
         withSlug?: string[];
         startsWith?: string;
@@ -264,9 +272,13 @@ export const prepareStoriesFromLocalFile = ({
 export const prepareMigrationConfigs = ({
     migrationConfig,
     componentsToMigrate,
+    migrationComponentAliases,
+    migrationComponentOverrides,
 }: {
     migrationConfig: string | string[];
     componentsToMigrate?: string[];
+    migrationComponentAliases?: MigrationComponentAliasesByMigration;
+    migrationComponentOverrides?: MigrationComponentOverridesByMigration;
 }): PreparedMigrationConfig[] => {
     const migrationConfigNames = normalizeMigrationConfigNames(migrationConfig);
 
@@ -319,15 +331,24 @@ export const prepareMigrationConfigs = ({
                 );
             }
 
+            const aliasedMigrationConfigFileContent =
+                extendMigrationMapperWithAliases(
+                    migrationConfigFileContent,
+                    migrationComponentAliases?.[migrationConfigName],
+                );
+
             const resolvedComponentsToMigrate =
-                componentsToMigrate && componentsToMigrate.length > 0
-                    ? componentsToMigrate
-                    : Object.keys(migrationConfigFileContent);
+                resolveMigrationComponentsToMigrate({
+                    mapper: aliasedMigrationConfigFileContent,
+                    migrationName: migrationConfigName,
+                    globalComponentsToMigrate: componentsToMigrate,
+                    perMigrationOverrides: migrationComponentOverrides,
+                });
 
             return {
                 migrationConfigName,
                 migrationConfigPath,
-                migrationConfigFileContent,
+                migrationConfigFileContent: aliasedMigrationConfigFileContent,
                 componentsToMigrate: resolvedComponentsToMigrate,
                 validator,
             };
@@ -742,6 +763,8 @@ export const migrateAllComponentsDataInStories = async (
         dryRun,
         fromFilePath,
         fileName,
+        migrationComponentAliases,
+        migrationComponentOverrides,
     }: Omit<MigrateItems, "componentsToMigrate" | "preparedMigrationConfigs">,
     config: RequestBaseConfig,
 ) => {
@@ -751,6 +774,8 @@ export const migrateAllComponentsDataInStories = async (
 
     const preparedMigrationConfigs = prepareMigrationConfigs({
         migrationConfig,
+        migrationComponentAliases,
+        migrationComponentOverrides,
     });
 
     if (storyblokConfig.debug) {
@@ -1022,6 +1047,8 @@ export const migrateProvidedComponentsDataInStories = async (
         fromFilePath,
         fileName,
         preparedMigrationConfigs,
+        migrationComponentAliases,
+        migrationComponentOverrides,
     }: MigrateItems,
     config: RequestBaseConfig,
 ) => {
@@ -1030,6 +1057,8 @@ export const migrateProvidedComponentsDataInStories = async (
         prepareMigrationConfigs({
             migrationConfig,
             componentsToMigrate,
+            migrationComponentAliases,
+            migrationComponentOverrides,
         });
 
     const itemsToMigrate = await loadItemsToMigrate(

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -22,12 +22,18 @@ import { isObjectEmpty } from "../../utils/object-utils.js";
 import { managementApi } from "../managementApi.js";
 
 import {
+    buildPreMigrationBackupBaseName,
+    resolveOutputFileBaseName,
+    shouldUseDatestampForArtifacts,
+} from "./file-naming.js";
+import {
     discoverMigrationValidatorForMigrationFile,
     MigrationValidationFailedError,
     runPreparedMigrationValidator,
     type MigrationValidationIssue,
     type PreparedMigrationValidator,
 } from "./migration-validation.js";
+import { summarizeMutationWriteResults } from "./write-summary.js";
 
 export type MigrateFrom = "file" | "space";
 
@@ -352,35 +358,6 @@ const deepClone = <T>(input: T): T => JSON.parse(JSON.stringify(input));
 
 const sumValues = (obj: Record<string, number>): number =>
     Object.values(obj).reduce((sum, value) => sum + value, 0);
-
-const sanitizeOutputFileBaseName = (value: string): string => {
-    const sanitized = value
-        .trim()
-        .replace(/[\\/]/g, "-")
-        .replace(/\s+/g, "-")
-        .replace(/[^a-zA-Z0-9._-]/g, "-")
-        .replace(/-+/g, "-")
-        .replace(/^[-.]+|[-.]+$/g, "");
-
-    return sanitized || "migration-output";
-};
-
-const resolveOutputFileBaseName = ({
-    from,
-    fileName,
-}: {
-    from: string;
-    fileName?: string;
-}): string => {
-    if (typeof fileName === "string" && fileName.trim().length > 0) {
-        return sanitizeOutputFileBaseName(fileName);
-    }
-
-    return sanitizeOutputFileBaseName(from);
-};
-
-const shouldUseDatestampForArtifacts = (fileName?: string): boolean =>
-    !(typeof fileName === "string" && fileName.trim().length > 0);
 
 const applySingleMigrationToItems = ({
     itemType,
@@ -958,8 +935,10 @@ export const doTheMigration = async (
         return;
     }
 
+    let writeResults: PromiseSettledResult<any>[] = [];
+
     if (itemType === "story") {
-        await managementApi.stories.updateStories(
+        writeResults = await managementApi.stories.updateStories(
             {
                 stories: pipelineResult.changedItems,
                 spaceId: to,
@@ -968,13 +947,37 @@ export const doTheMigration = async (
             config,
         );
     } else if (itemType === "preset") {
-        await managementApi.presets.updatePresets(
+        writeResults = await managementApi.presets.updatePresets(
             {
                 presets: pipelineResult.changedItems,
                 spaceId: to,
                 options: {},
             },
             config,
+        );
+    }
+
+    const writeSummary = summarizeMutationWriteResults(writeResults);
+
+    if (writeSummary.failed === 0) {
+        Logger.success(
+            `[MIGRATION] Update complete. ${writeSummary.successful}/${writeSummary.total} ${itemType}(s) updated successfully.`,
+        );
+        return;
+    }
+
+    Logger.warning(
+        `[MIGRATION] Update complete with partial failures. ${writeSummary.successful}/${writeSummary.total} ${itemType}(s) updated successfully, ${writeSummary.failed} failed.`,
+    );
+
+    writeSummary.failedItems.slice(0, 10).forEach((item) => {
+        const label = item.slug || item.name || item.id || "unknown";
+        Logger.error(`[MIGRATION] Failed ${itemType}: ${String(label)}`);
+    });
+
+    if (writeSummary.failedItems.length > 10) {
+        Logger.warning(
+            `[MIGRATION] Showing first 10 failed ${itemType}(s) only.`,
         );
     }
 };
@@ -1042,17 +1045,14 @@ export const migrateProvidedComponentsDataInStories = async (
 
     if (migrateFrom === "space" && !dryRun) {
         const backupFolder = path.join("backup", itemType);
-        const migrationLabel = resolvedMigrationConfigs
-            .map(
-                (preparedMigrationConfig) =>
-                    preparedMigrationConfig.migrationConfigName,
-            )
-            .join("__");
 
         await saveBackupToFile(
             {
                 itemType,
-                filename: `before__${migrationLabel}__${from}`,
+                filename: buildPreMigrationBackupBaseName({
+                    from,
+                    fileName,
+                }),
                 folder: backupFolder,
                 res: itemsToMigrate,
             },

--- a/src/api/data-migration/file-naming.ts
+++ b/src/api/data-migration/file-naming.ts
@@ -1,0 +1,45 @@
+export const sanitizeOutputFileBaseName = (value: string): string => {
+    const sanitized = value
+        .trim()
+        .replace(/[\\/]/g, "-")
+        .replace(/\s+/g, "-")
+        .replace(/[^a-zA-Z0-9._-]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^[-.]+|[-.]+$/g, "");
+
+    return sanitized || "migration-output";
+};
+
+export const resolveOutputFileBaseName = ({
+    from,
+    fileName,
+}: {
+    from: string;
+    fileName?: string;
+}): string => {
+    if (typeof fileName === "string" && fileName.trim().length > 0) {
+        return sanitizeOutputFileBaseName(fileName);
+    }
+
+    return sanitizeOutputFileBaseName(from);
+};
+
+export const shouldUseDatestampForArtifacts = (fileName?: string): boolean =>
+    !(typeof fileName === "string" && fileName.trim().length > 0);
+
+export const buildPreMigrationBackupBaseName = ({
+    from,
+    fileName,
+}: {
+    from: string;
+    fileName?: string;
+}): string => `before__${resolveOutputFileBaseName({ from, fileName })}`;
+
+export const buildStoryBackupBaseName = ({
+    from,
+    fileName,
+}: {
+    from: string;
+    fileName?: string;
+}): string =>
+    `${resolveOutputFileBaseName({ from, fileName })}--backup-before-migration`;

--- a/src/api/data-migration/migration-component-scope.ts
+++ b/src/api/data-migration/migration-component-scope.ts
@@ -1,0 +1,134 @@
+import type { MapperDefinition } from "./component-data-migration.js";
+
+export type MigrationComponentAliasesByMigration = Record<
+    string,
+    Record<string, string[]>
+>;
+
+export type MigrationComponentOverridesByMigration = Record<string, string[]>;
+
+const normalizeFlagValues = (value: string | string[] | undefined): string[] => {
+    if (Array.isArray(value)) {
+        return value.filter(Boolean);
+    }
+
+    if (typeof value === "string" && value.length > 0) {
+        return [value];
+    }
+
+    return [];
+};
+
+export const parseMigrationComponentAliasFlags = (
+    value: string | string[] | undefined,
+): MigrationComponentAliasesByMigration => {
+    const result: MigrationComponentAliasesByMigration = {};
+
+    normalizeFlagValues(value).forEach((entry) => {
+        const [migrationName, mapping] = entry.split(":");
+        const [sourceComponent, aliasesRaw] = (mapping || "").split("=");
+        const aliases = (aliasesRaw || "")
+            .split(",")
+            .map((item) => item.trim())
+            .filter(Boolean);
+
+        if (!migrationName || !sourceComponent || aliases.length === 0) {
+            throw new Error(
+                `Invalid --migrationComponentAlias value '${entry}'. Expected '<migration>:<source>=<alias1>,<alias2>'.`,
+            );
+        }
+
+        result[migrationName] = result[migrationName] || {};
+        result[migrationName]![sourceComponent] = [
+            ...(result[migrationName]![sourceComponent] || []),
+            ...aliases,
+        ];
+    });
+
+    return result;
+};
+
+export const parseMigrationComponentOverrideFlags = (
+    value: string | string[] | undefined,
+): MigrationComponentOverridesByMigration => {
+    const result: MigrationComponentOverridesByMigration = {};
+
+    normalizeFlagValues(value).forEach((entry) => {
+        const [migrationName, componentsRaw] = entry.split(":");
+        const components = (componentsRaw || "")
+            .split(",")
+            .map((item) => item.trim())
+            .filter(Boolean);
+
+        if (!migrationName || components.length === 0) {
+            throw new Error(
+                `Invalid --migrationComponents value '${entry}'. Expected '<migration>:<component1>,<component2>'.`,
+            );
+        }
+
+        result[migrationName] = components;
+    });
+
+    return result;
+};
+
+export const extendMigrationMapperWithAliases = (
+    mapper: Record<string, MapperDefinition>,
+    aliases: Record<string, string[]> | undefined,
+): Record<string, MapperDefinition> => {
+    if (!aliases) {
+        return mapper;
+    }
+
+    const extendedMapper = { ...mapper };
+
+    Object.entries(aliases).forEach(([sourceComponent, extraComponents]) => {
+        const sourceMapper = mapper[sourceComponent];
+
+        if (!sourceMapper) {
+            throw new Error(
+                `Cannot alias migration component '${sourceComponent}' because it is not defined in the migration config.`,
+            );
+        }
+
+        extraComponents.forEach((extraComponent) => {
+            extendedMapper[extraComponent] = sourceMapper;
+        });
+    });
+
+    return extendedMapper;
+};
+
+export const resolveMigrationComponentsToMigrate = ({
+    mapper,
+    migrationName,
+    globalComponentsToMigrate,
+    perMigrationOverrides,
+}: {
+    mapper: Record<string, MapperDefinition>;
+    migrationName: string;
+    globalComponentsToMigrate?: string[];
+    perMigrationOverrides?: MigrationComponentOverridesByMigration;
+}): string[] => {
+    const resolvedComponents =
+        perMigrationOverrides?.[migrationName] &&
+        perMigrationOverrides[migrationName]!.length > 0
+            ? perMigrationOverrides[migrationName]!
+            : globalComponentsToMigrate && globalComponentsToMigrate.length > 0
+              ? globalComponentsToMigrate
+              : Object.keys(mapper);
+
+    const missingComponents = resolvedComponents.filter(
+        (componentName) => !mapper[componentName],
+    );
+
+    if (missingComponents.length > 0) {
+        throw new Error(
+            `Migration '${migrationName}' cannot run for unknown components: ${missingComponents.join(
+                ", ",
+            )}. Add aliases first or adjust the component override list.`,
+        );
+    }
+
+    return resolvedComponents;
+};

--- a/src/api/data-migration/write-summary.ts
+++ b/src/api/data-migration/write-summary.ts
@@ -1,0 +1,49 @@
+export interface MutationWriteResult {
+    ok: boolean;
+    id?: number | string;
+    name?: string;
+    slug?: string;
+    error?: unknown;
+}
+
+export interface MutationWriteSummary {
+    total: number;
+    successful: number;
+    failed: number;
+    failedItems: MutationWriteResult[];
+}
+
+export const summarizeMutationWriteResults = (
+    results: PromiseSettledResult<MutationWriteResult>[],
+): MutationWriteSummary => {
+    const failedItems: MutationWriteResult[] = [];
+    let successful = 0;
+
+    for (const result of results) {
+        if (result.status === "fulfilled" && result.value?.ok) {
+            successful++;
+            continue;
+        }
+
+        if (result.status === "fulfilled") {
+            failedItems.push(
+                result.value || {
+                    ok: false,
+                },
+            );
+            continue;
+        }
+
+        failedItems.push({
+            ok: false,
+            error: result.reason,
+        });
+    }
+
+    return {
+        total: results.length,
+        successful,
+        failed: failedItems.length,
+        failedItems,
+    };
+};

--- a/src/api/presets/presets.ts
+++ b/src/api/presets/presets.ts
@@ -86,12 +86,24 @@ export const updatePreset: UpdatePreset = (args, config: RequestBaseConfig) => {
             Logger.warning(
                 `Preset: '${p.preset.name}' with '${p.preset.id}' id has been updated.`,
             );
-            return res;
+            return {
+                ok: true,
+                id: p.preset.id,
+                name: p.preset.name,
+                data: res,
+            };
         })
-        .catch(() => {
+        .catch((error) => {
             Logger.error(
                 `Error happened. Preset: '${p.preset.name}' with '${p.preset.id}' id has been not updated.`,
             );
+
+            return {
+                ok: false,
+                id: p.preset.id,
+                name: p.preset.name,
+                error,
+            };
         });
 };
 

--- a/src/api/stories/stories.ts
+++ b/src/api/stories/stories.ts
@@ -189,9 +189,25 @@ export const updateStory: UpdateStory = (content, storyId, options, config) => {
         })
         .then((res: any) => {
             console.log(`${chalk.green(res.data.story.full_slug)} updated.`);
-            return res.data;
+            return {
+                ok: true,
+                id: res.data.story.id,
+                name: res.data.story.name,
+                slug: res.data.story.full_slug,
+                data: res.data,
+            };
         })
-        .catch((err: any) => console.error(err));
+        .catch((err: any) => {
+            console.error(err);
+
+            return {
+                ok: false,
+                id: storyId,
+                name: content?.name,
+                slug: content?.full_slug || content?.slug,
+                error: err,
+            };
+        });
 };
 
 export const updateStories: UpdateStories = (args, config) => {

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -91,6 +91,8 @@ export const migrateDescription = `
         --to              - Space ID to which you want to migrate
         --migrate-from    - Migrate from (space, file) default: space
         --migration       - File name of migration file (without extension). Can be repeated for ordered pipeline in content migration.
+        --migrationComponentAlias - Add extra component aliases for a migration. Repeatable. Format: <migration>:<source>=<alias1>,<alias2>
+        --migrationComponents - Override the exact component scope for a migration. Repeatable. Format: <migration>:<component1>,<component2>
         --withSlug        - Filter stories by full slug (can be repeated)
         --startsWith      - Filter stories by starts_with prefix
         --yes             - Skip ask for confirmation (dangerous, but useful in CI/CD)
@@ -100,6 +102,8 @@ export const migrateDescription = `
     EXAMPLES
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration migration-a --migration migration-b --migration migration-c
+        $ sb-mig migrate content --all --from 12345 --to 12345 --migration colorPickerModeValues --migrationComponentAlias colorPickerModeValues:sb-button=sb-open-drift-button
+        $ sb-mig migrate content --all --from 12345 --to 12345 --migration colorPickerModeValues --migrationComponentAlias colorPickerModeValues:sb-section=sb-tour-page-section --migrationComponents colorPickerModeValues:sb-section,sb-tour-page-section
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --withSlug blog/home --withSlug docs/getting-started
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --startsWith blog/
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration v3toV4AllMigrations --dry-run --fileName brand-hub-v3-v4-run

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -8,6 +8,10 @@ import {
     migrateProvidedComponentsDataInStories,
 } from "../../api/data-migration/component-data-migration.js";
 import { buildStoryBackupBaseName } from "../../api/data-migration/file-naming.js";
+import {
+    parseMigrationComponentAliasFlags,
+    parseMigrationComponentOverrideFlags,
+} from "../../api/data-migration/migration-component-scope.js";
 import { managementApi } from "../../api/managementApi.js";
 import { backupStories } from "../../api/stories/backup.js";
 import { createAndSaveToFile } from "../../utils/files.js";
@@ -54,6 +58,8 @@ export const migrate = async (props: CLIOptions) => {
         "fromFilePath",
         "pageId",
         "migration",
+        "migrationComponentAlias",
+        "migrationComponents",
         "yes",
         "withSlug",
         "startsWith",
@@ -85,6 +91,20 @@ export const migrate = async (props: CLIOptions) => {
             const migrationConfigs = normalizeMigrationFlags(
                 flags["migration"] as string | string[] | undefined,
             );
+            const migrationComponentAliases =
+                parseMigrationComponentAliasFlags(
+                    flags["migrationComponentAlias"] as
+                        | string
+                        | string[]
+                        | undefined,
+                );
+            const migrationComponentOverrides =
+                parseMigrationComponentOverrideFlags(
+                    flags["migrationComponents"] as
+                        | string
+                        | string[]
+                        | undefined,
+                );
             const dryRun = flags["dryRun"] as boolean | undefined;
             const fileName = flags["fileName"] as string | undefined;
             const withSlugFlag = flags["withSlug"] as
@@ -135,6 +155,8 @@ export const migrate = async (props: CLIOptions) => {
                             migrateFrom,
                             componentsToMigrate,
                             migrationConfig: migrationConfigs,
+                            migrationComponentAliases,
+                            migrationComponentOverrides,
                             filters: { withSlug, startsWith },
                             dryRun,
                             fromFilePath,
@@ -171,6 +193,8 @@ export const migrate = async (props: CLIOptions) => {
                             to,
                             migrateFrom,
                             migrationConfig: migrationConfigs,
+                            migrationComponentAliases,
+                            migrationComponentOverrides,
                             filters: { withSlug, startsWith },
                             dryRun,
                             fromFilePath,
@@ -210,6 +234,20 @@ export const migrate = async (props: CLIOptions) => {
             const migrationConfigs = normalizeMigrationFlags(
                 flags["migration"] as string | string[] | undefined,
             );
+            const migrationComponentAliases =
+                parseMigrationComponentAliasFlags(
+                    flags["migrationComponentAlias"] as
+                        | string
+                        | string[]
+                        | undefined,
+                );
+            const migrationComponentOverrides =
+                parseMigrationComponentOverrideFlags(
+                    flags["migrationComponents"] as
+                        | string
+                        | string[]
+                        | undefined,
+                );
             const fromFilePath = flags["fromFilePath"] as string | undefined;
             const migrateFromFlag = flags["migrateFrom"] as
                 | MigrateFrom
@@ -268,6 +306,8 @@ export const migrate = async (props: CLIOptions) => {
                             to,
                             migrateFrom,
                             migrationConfig: migrationConfigs[0] as string,
+                            migrationComponentAliases,
+                            migrationComponentOverrides,
                             dryRun,
                             fromFilePath,
                             fileName,

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -7,6 +7,7 @@ import {
     migrateAllComponentsDataInStories,
     migrateProvidedComponentsDataInStories,
 } from "../../api/data-migration/component-data-migration.js";
+import { buildStoryBackupBaseName } from "../../api/data-migration/file-naming.js";
 import { managementApi } from "../../api/managementApi.js";
 import { backupStories } from "../../api/stories/backup.js";
 import { createAndSaveToFile } from "../../utils/files.js";
@@ -115,9 +116,10 @@ export const migrate = async (props: CLIOptions) => {
                     if (!dryRun) {
                         await backupStories(
                             {
-                                filename: `${from}--backup-before-migration___${migrationConfigs.join(
-                                    "__",
-                                )}`,
+                                filename: buildStoryBackupBaseName({
+                                    from,
+                                    fileName,
+                                }),
                                 suffix: ".sb.stories",
                                 spaceId: from,
                             },

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -28,18 +28,22 @@ export const askForConfirmation = async (
         prompt: chalk.red(`${message} (y/n) > `),
     });
 
-    rl.prompt();
-    for await (const deletionConfirmation of rl) {
-        if (deletionConfirmation.trim() !== "y") {
-            await resolveNo();
-            process.exit(0);
-        } else {
-            if (deletionConfirmation) {
-                await resolveYes();
-
-                break;
-            }
-        }
+    try {
         rl.prompt();
+        for await (const deletionConfirmation of rl) {
+            if (deletionConfirmation.trim() !== "y") {
+                await resolveNo();
+                process.exit(0);
+            } else {
+                if (deletionConfirmation) {
+                    await resolveYes();
+
+                    break;
+                }
+            }
+            rl.prompt();
+        }
+    } finally {
+        rl.close();
     }
 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -78,6 +78,14 @@ app.migrate = () => ({
                 type: "string",
                 isMultiple: true,
             },
+            migrationComponentAlias: {
+                type: "string",
+                isMultiple: true,
+            },
+            migrationComponents: {
+                type: "string",
+                isMultiple: true,
+            },
             withSlug: {
                 type: "string",
                 isMultiple: true,


### PR DESCRIPTION
## Summary
- add CLI support for extending migration component scope per migration
- allow aliasing extra component names onto existing migration mapper keys
- allow overriding the exact per-migration component scope from the CLI

## Validation
- npm test -- __tests__/api/migration-component-scope.test.ts __tests__/api/file-naming.test.ts __tests__/api/write-summary.test.ts
- npm run typecheck
- npm run build