### PR TITLE
test: run live API checks on beta PRs

### DIFF
--- a/.github/workflows/test-live-api.yml
+++ b/.github/workflows/test-live-api.yml
@@ -1,6 +1,9 @@
 name: Live API Tests
 
 on:
+  pull_request:
+    branches:
+      - beta
   workflow_dispatch:
     inputs:
       node_version:
@@ -24,7 +27,7 @@ on:
           - "spaces"
 
 env:
-  NODE_VERSION: ${{ inputs.node_version || '20.x' }}
+  NODE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.node_version || '20.x' }}
 
 jobs:
   live-api-tests:
@@ -55,7 +58,7 @@ jobs:
           echo "STORYBLOK_OAUTH_TOKEN=${{ secrets.STORYBLOK_OAUTH_TOKEN }}" >> .env
 
       - name: Run Live API Tests (All)
-        if: ${{ inputs.test_scope == 'all' || inputs.test_scope == '' }}
+        if: ${{ github.event_name == 'pull_request' || inputs.test_scope == 'all' || inputs.test_scope == '' }}
         env:
           STORYBLOK_LIVE_TESTS: "true"
           STORYBLOK_SPACE_ID: ${{ secrets.STORYBLOK_SPACE_ID }}
@@ -100,4 +103,3 @@ jobs:
           echo "They require valid credentials in repository secrets:" >> $GITHUB_STEP_SUMMARY
           echo "- \`STORYBLOK_SPACE_ID\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`STORYBLOK_OAUTH_TOKEN\`" >> $GITHUB_STEP_SUMMARY
-

--- a/__tests__/api-live/stories.live.test.ts
+++ b/__tests__/api-live/stories.live.test.ts
@@ -191,7 +191,9 @@ describe("Stories API - Live Tests", () => {
                 );
 
                 expect(updated).toBeDefined();
-                expect(updated.story.name).toBe("Updated CRUD Test Story");
+                expect(updated.ok).toBe(true);
+                expect(updated.name).toBe("Updated CRUD Test Story");
+                expect(updated.data.story.name).toBe("Updated CRUD Test Story");
                 await waitForRateLimit(500);
 
                 // DELETE


### PR DESCRIPTION
## Summary
- trigger the live API workflow on pull requests targeting `beta`
- update the live stories CRUD test for the current `updateStory()` result shape

## Why
The stable release was blocked by a live stories API contract failure that should have been caught before merge. This wires the existing live test workflow into the beta PR path so those regressions fail earlier.

## Validation
- npm run typecheck
- npm run build
