### PR TITLE
feat(sync): add dry-run support

### DIFF
--- a/__tests__/api/datasources-dry-run.test.ts
+++ b/__tests__/api/datasources-dry-run.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { syncDatasourcesData } from "../../src/api/datasources/datasources.js";
+import {
+    createMockApiConfig,
+    createPaginatedResponse,
+} from "../mocks/storyblokClient.mock.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+describe("datasource sync dry-run", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("plans existing datasource updates without API writes", async () => {
+        const config = createMockApiConfig();
+
+        config.sbApi.get.mockImplementation((path: string) => {
+            if (path.includes("datasource_entries")) {
+                return Promise.resolve({
+                    data: {
+                        datasource_entries: [
+                            { id: 101, name: "red", value: "#f00" },
+                        ],
+                    },
+                });
+            }
+
+            return Promise.resolve(
+                createPaginatedResponse(
+                    [
+                        {
+                            id: 1,
+                            name: "colors",
+                            slug: "colors",
+                            dimensions: [],
+                        },
+                    ],
+                    "datasources",
+                ),
+            );
+        });
+
+        const result = await syncDatasourcesData(
+            {
+                datasources: [
+                    {
+                        name: "colors",
+                        slug: "colors",
+                        dimensions: [],
+                        datasource_entries: [
+                            { name: "red", value: "#ff0000" },
+                            { name: "blue", value: "#0000ff" },
+                        ],
+                    },
+                ],
+                dryRun: true,
+            },
+            config,
+        );
+
+        expect(result).toMatchObject({
+            created: [],
+            updated: ["colors"],
+            skipped: [],
+            errors: [],
+        });
+        expect(config.sbApi.post).not.toHaveBeenCalled();
+        expect(config.sbApi.put).not.toHaveBeenCalled();
+    });
+
+    it("plans new datasource creation without API writes", async () => {
+        const config = createMockApiConfig();
+        config.sbApi.get.mockResolvedValue(
+            createPaginatedResponse([], "datasources"),
+        );
+
+        const result = await syncDatasourcesData(
+            {
+                datasources: [
+                    {
+                        name: "colors",
+                        slug: "colors",
+                        dimensions: [],
+                        datasource_entries: [
+                            { name: "red", value: "#ff0000" },
+                        ],
+                    },
+                ],
+                dryRun: true,
+            },
+            config,
+        );
+
+        expect(result).toMatchObject({
+            created: ["colors"],
+            updated: [],
+            skipped: [],
+            errors: [],
+        });
+        expect(config.sbApi.post).not.toHaveBeenCalled();
+        expect(config.sbApi.put).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/api/sync-dry-run.test.ts
+++ b/__tests__/api/sync-dry-run.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { syncComponentsData } from "../../src/api/components/components.sync.js";
+import { syncPluginsData } from "../../src/api/plugins/plugins.js";
+import { syncRolesData } from "../../src/api/roles/roles.js";
+import {
+    createMockApiConfig,
+    createPaginatedResponse,
+} from "../mocks/storyblokClient.mock.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+describe("sync dry-run", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("plans component creates and updates without API writes", async () => {
+        const config = createMockApiConfig();
+
+        config.sbApi.get.mockImplementation((path: string) => {
+            if (path.includes("component_groups")) {
+                return Promise.resolve(
+                    createPaginatedResponse([], "component_groups"),
+                );
+            }
+
+            return Promise.resolve(
+                createPaginatedResponse(
+                    [{ id: 1, name: "hero" }],
+                    "components",
+                ),
+            );
+        });
+
+        const result = await syncComponentsData(
+            {
+                components: [{ name: "hero" }, { name: "card" }],
+                presets: false,
+                dryRun: true,
+            },
+            config,
+        );
+
+        expect(result).toMatchObject({
+            created: ["card"],
+            updated: ["hero"],
+            skipped: [],
+            errors: [],
+        });
+        expect(config.sbApi.post).not.toHaveBeenCalled();
+        expect(config.sbApi.put).not.toHaveBeenCalled();
+        expect(config.sbApi.delete).not.toHaveBeenCalled();
+    });
+
+    it("plans role creates and updates without API writes", async () => {
+        const config = createMockApiConfig();
+        config.sbApi.get.mockResolvedValue(
+            createPaginatedResponse(
+                [{ id: 1, role: "Editor" }],
+                "space_roles",
+            ),
+        );
+
+        const result = await syncRolesData(
+            {
+                roles: [{ role: "Editor" }, { role: "Publisher" }],
+                dryRun: true,
+            },
+            config,
+        );
+
+        expect(result).toMatchObject({
+            created: ["Publisher"],
+            updated: ["Editor"],
+            skipped: [],
+            errors: [],
+        });
+        expect(config.sbApi.post).not.toHaveBeenCalled();
+        expect(config.sbApi.put).not.toHaveBeenCalled();
+    });
+
+    it("plans plugin creates and updates without API writes", async () => {
+        const config = createMockApiConfig();
+        config.sbApi.get.mockResolvedValue(
+            createPaginatedResponse(
+                [{ id: 1, name: "color-picker" }],
+                "field_types",
+            ),
+        );
+
+        const result = await syncPluginsData(
+            {
+                plugins: [
+                    { name: "color-picker", body: "" },
+                    { name: "link-picker", body: "" },
+                ],
+                dryRun: true,
+            },
+            config,
+        );
+
+        expect(result).toMatchObject({
+            created: ["link-picker"],
+            updated: ["color-picker"],
+            skipped: [],
+            errors: [],
+        });
+        expect(config.sbApi.post).not.toHaveBeenCalled();
+        expect(config.sbApi.put).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/cli-sync-datasources.test.ts
+++ b/__tests__/cli-sync-datasources.test.ts
@@ -92,4 +92,31 @@ describe("Datasource sync CLI helpers", () => {
             syncProvidedDatasources({ datasources: ["colors"] }, {} as any),
         );
     });
+
+    it("passes dry-run through for --all datasource sync", async () => {
+        await syncAllDatasources({} as any, { dryRun: true });
+
+        expect(syncDatasources).toHaveBeenCalledWith(
+            {
+                providedDatasources: [],
+                dryRun: true,
+            },
+            {},
+        );
+    });
+
+    it("passes dry-run through for provided datasource names", async () => {
+        await syncProvidedDatasources(
+            { datasources: ["colors"], dryRun: true },
+            {} as any,
+        );
+
+        expect(syncDatasources).toHaveBeenCalledWith(
+            {
+                providedDatasources: [],
+                dryRun: true,
+            },
+            {},
+        );
+    });
 });

--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -14,6 +14,10 @@
         "lib": ["DOM", "DOM.Iterable", "ESNext"],
         "baseUrl": "..",
         "paths": {
+            "@storyblok/react": [
+                "node_modules/@storyblok/react/dist/types/index.d.ts",
+                "sb-mig/node_modules/@storyblok/react/dist/types/index.d.ts"
+            ],
             "../src/*": ["src/*"]
         }
     },

--- a/src/api-v2/sync/index.ts
+++ b/src/api-v2/sync/index.ts
@@ -19,40 +19,12 @@ export async function syncComponents(
 ): Promise<SyncResult> {
     const presets = args.presets ?? false;
 
-    if (args.dryRun) {
-        // minimal dry-run: compare names against remote
-        const remote = await client.sbApi.get(
-            `spaces/${client.spaceId}/components/`,
-            {
-                per_page: 100,
-                page: 1,
-            },
-        );
-        const remoteNames = new Set(
-            (remote as any).data?.components?.map((c: any) => c.name) ?? [],
-        );
-        const created: string[] = [];
-        const updated: string[] = [];
-        const skipped: string[] = [];
-
-        for (const c of args.components) {
-            const name = String(c?.name ?? "unknown");
-            if (!c?.name) {
-                skipped.push(name);
-                continue;
-            }
-            if (remoteNames.has(c.name)) updated.push(name);
-            else created.push(name);
-        }
-
-        return { created, updated, skipped, errors: [] };
-    }
-
     return (await syncComponentsData(
         {
             components: args.components,
             presets,
             ssot: args.ssot,
+            dryRun: args.dryRun,
             onProgress: args.onProgress,
         },
         toRequestConfig(client),
@@ -63,32 +35,8 @@ export async function syncDatasources(
     client: ApiClient,
     args: { datasources: any[]; dryRun?: boolean },
 ): Promise<SyncResult> {
-    if (args.dryRun) {
-        const remote = await client.sbApi.get(
-            `spaces/${client.spaceId}/datasources/`,
-        );
-        const remoteNames = new Set(
-            (remote as any).data?.datasources?.map((d: any) => d.name) ?? [],
-        );
-        const created: string[] = [];
-        const updated: string[] = [];
-        const skipped: string[] = [];
-
-        for (const d of args.datasources) {
-            const name = String(d?.name ?? "unknown");
-            if (!d?.name) {
-                skipped.push(name);
-                continue;
-            }
-            if (remoteNames.has(d.name)) updated.push(name);
-            else created.push(name);
-        }
-
-        return { created, updated, skipped, errors: [] };
-    }
-
     return (await syncDatasourcesData(
-        { datasources: args.datasources },
+        { datasources: args.datasources, dryRun: args.dryRun },
         toRequestConfig(client),
     )) as any;
 }
@@ -97,36 +45,8 @@ export async function syncRoles(
     client: ApiClient,
     args: { roles: any[]; dryRun?: boolean },
 ): Promise<SyncResult> {
-    if (args.dryRun) {
-        const remote = await client.sbApi.get(
-            `spaces/${client.spaceId}/space_roles/`,
-            {
-                per_page: 100,
-                page: 1,
-            },
-        );
-        const remoteNames = new Set(
-            (remote as any).data?.space_roles?.map((r: any) => r.role) ?? [],
-        );
-        const created: string[] = [];
-        const updated: string[] = [];
-        const skipped: string[] = [];
-
-        for (const r of args.roles) {
-            const name = String(r?.role ?? "unknown");
-            if (!r?.role) {
-                skipped.push(name);
-                continue;
-            }
-            if (remoteNames.has(r.role)) updated.push(name);
-            else created.push(name);
-        }
-
-        return { created, updated, skipped, errors: [] };
-    }
-
     return (await syncRolesData(
-        { roles: args.roles },
+        { roles: args.roles, dryRun: args.dryRun },
         toRequestConfig(client),
     )) as any;
 }
@@ -135,33 +55,8 @@ export async function syncPlugins(
     client: ApiClient,
     args: { plugins: { name: string; body: string }[]; dryRun?: boolean },
 ): Promise<SyncResult> {
-    if (args.dryRun) {
-        const remote = await client.sbApi.get("field_types", {
-            per_page: 100,
-            page: 1,
-        });
-        const remoteNames = new Set(
-            (remote as any).data?.field_types?.map((p: any) => p.name) ?? [],
-        );
-        const created: string[] = [];
-        const updated: string[] = [];
-        const skipped: string[] = [];
-
-        for (const p of args.plugins) {
-            const name = String(p?.name ?? "unknown");
-            if (!p?.name) {
-                skipped.push(name);
-                continue;
-            }
-            if (remoteNames.has(p.name)) updated.push(name);
-            else created.push(name);
-        }
-
-        return { created, updated, skipped, errors: [] };
-    }
-
     return (await syncPluginsData(
-        { plugins: args.plugins },
+        { plugins: args.plugins, dryRun: args.dryRun },
         toRequestConfig(client),
     )) as any;
 }

--- a/src/api/components/components.sync.ts
+++ b/src/api/components/components.sync.ts
@@ -1,4 +1,8 @@
-import type { SyncProgressCallback, SyncResult } from "../sync/sync.types.js";
+import type {
+    SyncOptions,
+    SyncProgressCallback,
+    SyncResult,
+} from "../sync/sync.types.js";
 import type { RequestBaseConfig } from "../utils/request.js";
 
 import { uniqueValuesFrom } from "../../utils/array-utils.js";
@@ -45,6 +49,7 @@ import {
 async function ensureComponentGroupsExist(
     groupNames: string[],
     config: RequestBaseConfig,
+    options: SyncOptions = {},
 ): Promise<void> {
     try {
         const existing = await getAllComponentsGroups(config);
@@ -52,6 +57,13 @@ async function ensureComponentGroupsExist(
 
         for (const groupName of groupNames) {
             if (!existingNames.has(groupName)) {
+                if (options.dryRun) {
+                    Logger.warning(
+                        `[dry-run] Would create component group '${groupName}'.`,
+                    );
+                    continue;
+                }
+
                 await createComponentsGroup(groupName, config);
             }
         }
@@ -80,11 +92,12 @@ export async function syncComponentsData(
         components: any[];
         presets: boolean;
         ssot?: boolean;
+        dryRun?: boolean;
         onProgress?: SyncProgressCallback;
     },
     config: RequestBaseConfig,
 ): Promise<SyncResult> {
-    const { components, presets, ssot, onProgress } = args;
+    const { components, presets, ssot, dryRun, onProgress } = args;
     const progress = onProgress ?? defaultProgress;
 
     const result: SyncResult = {
@@ -94,17 +107,37 @@ export async function syncComponentsData(
         errors: [],
     };
 
+    if (dryRun) {
+        Logger.warning(
+            "[dry-run] Component sync will only read remote data and report planned changes.",
+        );
+    }
+
     if (ssot) {
         const existingComponents = await getAllComponents(config);
         const existingGroups = await getAllComponentsGroups(config);
-        await Promise.allSettled([
-            ...(existingComponents ?? []).map((c: any) =>
-                removeComponent(c, config),
-            ),
-            ...(existingGroups ?? []).map((g: any) =>
-                removeComponentGroup(g, config),
-            ),
-        ]);
+
+        if (dryRun) {
+            for (const component of existingComponents ?? []) {
+                Logger.warning(
+                    `[dry-run] Would remove component '${component.name}'.`,
+                );
+            }
+            for (const group of existingGroups ?? []) {
+                Logger.warning(
+                    `[dry-run] Would remove component group '${group.name}'.`,
+                );
+            }
+        } else {
+            await Promise.allSettled([
+                ...(existingComponents ?? []).map((c: any) =>
+                    removeComponent(c, config),
+                ),
+                ...(existingGroups ?? []).map((g: any) =>
+                    removeComponentGroup(g, config),
+                ),
+            ]);
+        }
     }
 
     const nonEmptyComponents = components.filter((c) => !isObjectEmpty(c));
@@ -114,13 +147,14 @@ export async function syncComponentsData(
             .map((c) => c.component_group_name),
     );
 
-    await ensureComponentGroupsExist(groupsToCheck, config);
+    await ensureComponentGroupsExist(groupsToCheck, config, { dryRun });
 
     let remoteComponents: any[] = [];
     let remoteGroups: any[] = [];
 
     try {
-        remoteComponents = (await getAllComponents(config)) ?? [];
+        remoteComponents =
+            ssot && dryRun ? [] : ((await getAllComponents(config)) ?? []);
     } catch (error) {
         Logger.warning(
             `Could not fetch remote components: ${error instanceof Error ? error.message : String(error)}`,
@@ -182,6 +216,19 @@ export async function syncComponentsData(
         });
 
         try {
+            if (dryRun) {
+                Logger.warning(`[dry-run] Would update component '${name}'.`);
+                result.updated.push(name);
+                progress({
+                    type: "progress",
+                    current: currentIndex,
+                    total: totalComponents,
+                    name,
+                    action: "updated",
+                });
+                continue;
+            }
+
             await updateComponent(component, presets, config);
             result.updated.push(name);
             progress({
@@ -221,6 +268,19 @@ export async function syncComponentsData(
         });
 
         try {
+            if (dryRun) {
+                Logger.warning(`[dry-run] Would create component '${name}'.`);
+                result.created.push(name);
+                progress({
+                    type: "progress",
+                    current: currentIndex,
+                    total: totalComponents,
+                    name,
+                    action: "created",
+                });
+                continue;
+            }
+
             await createComponent(component, presets, config);
             result.created.push(name);
             progress({

--- a/src/api/datasources/datasource-entries.ts
+++ b/src/api/datasources/datasource-entries.ts
@@ -95,16 +95,30 @@ export const createDatasourceEntries: CreateDatasourceEntries = (
     args,
     config,
 ) => {
-    const { datasource_entries, remoteDatasourceEntries, data } = args;
+    const { datasource_entries, remoteDatasourceEntries, data, dryRun } = args;
+    const remoteEntries = Array.isArray(
+        remoteDatasourceEntries?.datasource_entries,
+    )
+        ? remoteDatasourceEntries.datasource_entries
+        : [];
 
     return Promise.all(
         datasource_entries.map((datasourceEntry: any) => {
-            const datasourceToBeUpdated =
-                remoteDatasourceEntries.datasource_entries.find(
-                    (remoteDatasourceEntry: any) =>
-                        remoteDatasourceEntry.name ===
-                        Object.values(datasourceEntry)[0],
+            const datasourceEntryName =
+                datasourceEntry.name ?? Object.values(datasourceEntry)[0];
+            const datasourceToBeUpdated = remoteEntries.find(
+                (remoteDatasourceEntry: any) =>
+                    remoteDatasourceEntry.name === datasourceEntryName,
+            );
+
+            if (dryRun) {
+                const action = datasourceToBeUpdated ? "update" : "create";
+                Logger.warning(
+                    `[dry-run] Would ${action} datasource entry '${datasourceEntryName}' in '${data.datasource.name}' datasource.`,
                 );
+                return data;
+            }
+
             if (datasourceToBeUpdated) {
                 return updateDatasourceEntry(
                     { data, datasourceEntry, datasourceToBeUpdated },
@@ -115,6 +129,13 @@ export const createDatasourceEntries: CreateDatasourceEntries = (
         }),
     )
         .then((_: any) => {
+            if (dryRun) {
+                Logger.warning(
+                    `[dry-run] Datasource entries for ${data.datasource.id} datasource id were planned without API writes.`,
+                );
+                return data;
+            }
+
             Logger.success(
                 `Datasource entries for ${data.datasource.id} datasource id has been successfully synced.`,
             );

--- a/src/api/datasources/datasources.sync.ts
+++ b/src/api/datasources/datasources.sync.ts
@@ -6,7 +6,7 @@ import Logger from "../../utils/logger.js";
 import { syncDatasourcesData } from "./datasources.js";
 
 export const syncDatasources: SyncDatasources = async (args, config) => {
-    const { providedDatasources } = args;
+    const { providedDatasources, dryRun } = args;
     Logger.log(`Trying to sync provided datasources: `);
 
     const providedDatasourcesContent = await Promise.all(
@@ -16,7 +16,7 @@ export const syncDatasources: SyncDatasources = async (args, config) => {
     );
 
     await syncDatasourcesData(
-        { datasources: providedDatasourcesContent },
+        { datasources: providedDatasourcesContent, dryRun },
         config,
     );
 };

--- a/src/api/datasources/datasources.ts
+++ b/src/api/datasources/datasources.ts
@@ -151,7 +151,7 @@ export const updateDatasource: UpdateDatasource = (args, config) => {
 // File-based sync wrapper lives in `datasources.sync.ts` to keep this module CJS-safe.
 
 export const syncDatasourcesData = async (
-    { datasources }: { datasources: any[] },
+    { datasources, dryRun }: { datasources: any[]; dryRun?: boolean },
     config: any,
 ): Promise<SyncResult> => {
     const result: SyncResult = {
@@ -160,6 +160,12 @@ export const syncDatasourcesData = async (
         skipped: [],
         errors: [],
     };
+
+    if (dryRun) {
+        Logger.warning(
+            "[dry-run] Datasource sync will only read remote data and report planned changes.",
+        );
+    }
 
     const remoteDatasourcesRaw = await getAllDatasources(config);
     const remoteDatasources = Array.isArray(remoteDatasourcesRaw)
@@ -178,6 +184,52 @@ export const syncDatasourcesData = async (
                 (remoteDatasource: any) =>
                     datasource.name === remoteDatasource.name,
             );
+
+            if (dryRun) {
+                if (datasourceToBeUpdated) {
+                    result.updated.push(name);
+                    Logger.warning(
+                        `[dry-run] Would update datasource '${name}'.`,
+                    );
+
+                    const remoteDatasourceEntries = await getDatasourceEntries(
+                        {
+                            datasourceName: name,
+                        },
+                        config,
+                    );
+
+                    await createDatasourceEntries(
+                        {
+                            data: { datasource: datasourceToBeUpdated },
+                            datasource_entries:
+                                datasource.datasource_entries ?? [],
+                            remoteDatasourceEntries,
+                            dryRun,
+                        },
+                        config,
+                    );
+                } else {
+                    const entriesCount = Array.isArray(
+                        datasource.datasource_entries,
+                    )
+                        ? datasource.datasource_entries.length
+                        : 0;
+
+                    result.created.push(name);
+                    Logger.warning(
+                        `[dry-run] Would create datasource '${name}'.`,
+                    );
+
+                    if (entriesCount > 0) {
+                        Logger.warning(
+                            `[dry-run] Would create ${entriesCount} datasource entries for '${name}' after datasource creation.`,
+                        );
+                    }
+                }
+
+                continue;
+            }
 
             const opResult = datasourceToBeUpdated
                 ? await updateDatasource(

--- a/src/api/datasources/datasources.types.ts
+++ b/src/api/datasources/datasources.types.ts
@@ -17,15 +17,16 @@ export type UpdateDatasource = (
 ) => Promise<any>;
 
 export type SyncDatasources = (
-    args: { providedDatasources: OneFileElement[] },
+    args: { providedDatasources: OneFileElement[]; dryRun?: boolean },
     config: RequestBaseConfig,
 ) => Promise<any>;
 export type SyncProvidedDatasources = (
-    args: { datasources: string[] },
+    args: { datasources: string[]; dryRun?: boolean },
     config: RequestBaseConfig,
 ) => Promise<void>;
 export type SyncAllDatasources = (
     config: RequestBaseConfig,
+    args?: { dryRun?: boolean },
 ) => Promise<void>;
 
 // Datasource Entries
@@ -38,6 +39,7 @@ export type CreateDatasourceEntries = (
         data: any;
         datasource_entries: any;
         remoteDatasourceEntries: any;
+        dryRun?: boolean;
     },
     config: RequestBaseConfig,
 ) => Promise<any> | void;

--- a/src/api/migrate.ts
+++ b/src/api/migrate.ts
@@ -134,6 +134,7 @@ export const syncComponents: SyncComponents = async (
     specifiedComponents,
     presets,
     config,
+    options = {},
 ) => {
     Logger.log("sync2Components: ");
 
@@ -153,12 +154,21 @@ export const syncComponents: SyncComponents = async (
     );
 
     await syncComponentsData(
-        { components: specifiedComponentsContent, presets },
+        {
+            components: specifiedComponentsContent,
+            presets,
+            ssot: options.ssot,
+            dryRun: options.dryRun,
+        },
         config,
     );
 };
 
-export const syncAllComponents: SyncAllComponents = async (presets, config) => {
+export const syncAllComponents: SyncAllComponents = async (
+    presets,
+    config,
+    options = {},
+) => {
     // #1: discover all external .sb.js files
     const allLocalSbComponentsSchemaFiles = await discover({
         scope: SCOPE.local,
@@ -178,7 +188,10 @@ export const syncAllComponents: SyncAllComponents = async (presets, config) => {
     });
 
     // #4: sync - do all stuff already done (groups resolving, and so on)
-    return await syncComponents([...local, ...external], presets, config);
+    return await syncComponents([...local, ...external], presets, config, {
+        dryRun: options.dryRun,
+        ssot: options.ssot,
+    });
 };
 
 export const syncProvidedComponents: SyncProvidedComponents = async (
@@ -186,6 +199,7 @@ export const syncProvidedComponents: SyncProvidedComponents = async (
     components,
     packageName,
     config,
+    options = {},
 ) => {
     if (!packageName) {
         // #1: discover all external .sb.js files
@@ -208,7 +222,9 @@ export const syncProvidedComponents: SyncProvidedComponents = async (
         });
 
         // #4: sync - do all stuff already done (groups resolving, and so on)
-        return await syncComponents([...local, ...external], presets, config);
+        return await syncComponents([...local, ...external], presets, config, {
+            dryRun: options.dryRun,
+        });
     } else {
         // implement discovering and syncrhonizing with packageName
         // #1: discover all external .sb.js files
@@ -227,19 +243,30 @@ export const syncProvidedComponents: SyncProvidedComponents = async (
             external: allExternalSbComponentsSchemaFiles,
         });
         // #4: sync - do all stuff already done (groups resolving, and so on)
-        return syncComponents([...local, ...external], presets, config);
+        return syncComponents([...local, ...external], presets, config, {
+            dryRun: options.dryRun,
+        });
     }
 };
 
 export const syncAssets: SyncAssets = async (
-    { transmission: { from, to }, syncDirection },
+    { transmission: { from, to }, syncDirection, dryRun },
     config,
 ) => {
     Logger.log(`We would try to migrate Assets data from: ${from} to: ${to}`);
 
     const allAssets = await getAllAssets({ spaceId: from }, config);
+    const assets = Array.isArray(allAssets?.assets) ? allAssets.assets : [];
+
+    if (dryRun) {
+        Logger.warning(
+            `[dry-run] Would sync ${assets.length} assets from ${from} to ${to}.`,
+        );
+        return true;
+    }
+
     await Promise.all(
-        allAssets.assets.map((asset) => {
+        assets.map((asset) => {
             const { id, created_at, updated_at, ...newAssetPayload } = asset;
             return migrateAsset(
                 {
@@ -251,10 +278,12 @@ export const syncAssets: SyncAssets = async (
             );
         }),
     );
+
+    return true;
 };
 
 const syncStories: SyncStories = async (
-    { transmission: { from, to }, stories, toSpaceId },
+    { transmission: { from, to }, stories, toSpaceId, dryRun },
     config,
 ) => {
     Logger.log(`We would try to migrate Stories data from: ${from} to: ${to}`);
@@ -266,6 +295,13 @@ const syncStories: SyncStories = async (
         );
 
     Logger.warning(`Amount of all stories to migrate: ${storiesToPass.length}`);
+
+    if (dryRun) {
+        Logger.warning(
+            `[dry-run] Would sync ${storiesToPass.length} stories from ${from} to ${to}.`,
+        );
+        return true;
+    }
 
     const storiesToPassJson = JSON.stringify(storiesToPass, null, 2);
 
@@ -283,14 +319,37 @@ const syncStories: SyncStories = async (
         { tree, realParentId: null, spaceId: toSpaceId },
         config,
     );
+
+    return true;
 };
 
 export const syncContent: SyncContentFunction = async (
-    { type, transmission, syncDirection, filename },
+    { type, transmission, syncDirection, filename, dryRun },
     config,
 ) => {
+    if (dryRun) {
+        Logger.warning(
+            "[dry-run] Content sync will only read source data and report planned changes.",
+        );
+    }
+
     if (type === "stories") {
         if (syncDirection === "fromSpaceToFile") {
+            if (dryRun) {
+                const stories = await getAllStories(
+                    {},
+                    {
+                        ...config,
+                        spaceId: transmission.from,
+                        sbApi: config.sbApi,
+                    },
+                );
+                Logger.warning(
+                    `[dry-run] Would back up ${stories.length} stories from ${transmission.from} to '${transmission.to}'.`,
+                );
+                return true;
+            }
+
             await backupStories(
                 {
                     filename: transmission.to,
@@ -315,6 +374,7 @@ export const syncContent: SyncContentFunction = async (
                     transmission,
                     stories,
                     toSpaceId: transmission.to,
+                    dryRun,
                 },
                 config,
             );
@@ -336,6 +396,7 @@ export const syncContent: SyncContentFunction = async (
                     transmission,
                     stories: storiesFileContent[0],
                     toSpaceId: transmission.to,
+                    dryRun,
                 },
                 config,
             );
@@ -352,6 +413,7 @@ export const syncContent: SyncContentFunction = async (
                     transmission,
                     stories: data.stories,
                     toSpaceId: transmission.to,
+                    dryRun,
                 },
                 config,
             );
@@ -367,7 +429,7 @@ export const syncContent: SyncContentFunction = async (
             syncDirection === "fromSpaceToSpace" ||
             syncDirection === "fromSpaceToFile"
         ) {
-            await syncAssets({ transmission, syncDirection }, config);
+            await syncAssets({ transmission, syncDirection, dryRun }, config);
         } else {
             Logger.warning(
                 `${syncDirection} with ${type} This is not implemented yet!`,

--- a/src/api/migrate.types.ts
+++ b/src/api/migrate.types.ts
@@ -1,22 +1,26 @@
 import type { RequestBaseConfig } from "./utils/request.js";
 import type { SyncDirection } from "../cli/sync.types.js";
+import type { SyncOptions } from "./sync/sync.types.js";
 import type { OneFileElement } from "../cli/utils/discover.js";
 
 export type SyncComponents = (
     specifiedComponents: OneFileElement[],
     presets: boolean,
     config: RequestBaseConfig,
+    options?: SyncOptions & { ssot?: boolean },
 ) => Promise<any>;
 
 export type SyncAllComponents = (
     presets: boolean,
     config: RequestBaseConfig,
+    options?: SyncOptions & { ssot?: boolean },
 ) => Promise<any>;
 export type SyncProvidedComponents = (
     presets: boolean,
     components: string[],
     packageName: boolean,
     config: RequestBaseConfig,
+    options?: SyncOptions,
 ) => Promise<any>;
 
 // interface SyncAllComponents {
@@ -34,10 +38,12 @@ export type SyncStories = (
         transmission,
         stories,
         toSpaceId,
+        dryRun,
     }: {
         transmission: SyncContent["transmission"];
         stories: any[];
         toSpaceId: string;
+        dryRun?: boolean;
     },
     config: RequestBaseConfig,
 ) => Promise<any>;
@@ -50,19 +56,22 @@ export interface SyncContent {
     };
     syncDirection: SyncDirection;
     filename?: string;
+    dryRun?: boolean;
 }
 
 export type SyncContentFunction = (
-    { type, transmission, syncDirection, filename }: SyncContent,
+    { type, transmission, syncDirection, filename, dryRun }: SyncContent,
     config: RequestBaseConfig,
 ) => Promise<any>;
 
 export type SyncAssets = (
     {
         transmission,
+        dryRun,
     }: {
         transmission: SyncContent["transmission"];
         syncDirection: SyncDirection;
+        dryRun?: boolean;
     },
     config: RequestBaseConfig,
 ) => Promise<any>;

--- a/src/api/plugins/plugins.sync.ts
+++ b/src/api/plugins/plugins.sync.ts
@@ -5,17 +5,21 @@ import { readFile } from "../../utils/files.js";
 import { syncPluginsData } from "./plugins.js";
 
 export const syncProvidedPlugins: SyncProvidedPlugins = async (
-    { plugins },
+    { plugins, dryRun },
     config,
 ) => {
-    const body = await readFile("dist/export.js");
-    if (!body) {
+    const body = dryRun ? "" : await readFile("dist/export.js");
+    if (!body && !dryRun) {
         throw new Error("Unable to read plugin bundle from dist/export.js");
     }
 
     await syncPluginsData(
         {
-            plugins: plugins.map((name) => ({ name: String(name), body })),
+            plugins: plugins.map((name) => ({
+                name: String(name),
+                body: body ?? "",
+            })),
+            dryRun,
         },
         config,
     );

--- a/src/api/plugins/plugins.ts
+++ b/src/api/plugins/plugins.ts
@@ -113,7 +113,10 @@ export const createPlugin: CreatePlugin = (pluginName: string, config) => {
 // File-based sync wrapper lives in `plugins.sync.ts` to keep this module CJS-safe.
 
 export const syncPluginsData = async (
-    { plugins }: { plugins: { name: string; body: string }[] },
+    {
+        plugins,
+        dryRun,
+    }: { plugins: { name: string; body: string }[]; dryRun?: boolean },
     config: any,
 ): Promise<SyncResult> => {
     const result: SyncResult = {
@@ -123,6 +126,14 @@ export const syncPluginsData = async (
         errors: [],
     };
 
+    if (dryRun) {
+        Logger.warning(
+            "[dry-run] Plugin sync will only read remote data and report planned changes.",
+        );
+    }
+
+    const remotePlugins = dryRun ? await getAllPlugins(config) : [];
+
     for (const p of plugins) {
         const name = String(p?.name ?? "unknown");
         if (!p?.name) {
@@ -131,6 +142,24 @@ export const syncPluginsData = async (
         }
 
         try {
+            if (dryRun) {
+                const plugin = Array.isArray(remotePlugins)
+                    ? remotePlugins.find(
+                          (remotePlugin: any) => remotePlugin.name === name,
+                      )
+                    : undefined;
+
+                if (plugin) {
+                    Logger.warning(`[dry-run] Would update plugin '${name}'.`);
+                    result.updated.push(name);
+                } else {
+                    Logger.warning(`[dry-run] Would create plugin '${name}'.`);
+                    result.created.push(name);
+                }
+
+                continue;
+            }
+
             const plugin = await getPlugin(name, config);
             if (plugin) {
                 await updatePlugin(

--- a/src/api/plugins/plugins.types.ts
+++ b/src/api/plugins/plugins.types.ts
@@ -13,6 +13,7 @@ interface UpdatePluginDTO {
 
 interface SyncProvidedPluginsDTO {
     plugins: string[];
+    dryRun?: boolean;
 }
 
 export type GetPlugin = (

--- a/src/api/roles/roles.sync.ts
+++ b/src/api/roles/roles.sync.ts
@@ -4,12 +4,15 @@ import { getFileContentWithRequire } from "../../utils/files.js";
 
 import { syncRolesData } from "./roles.js";
 
-export const syncRoles: SyncRoles = async ({ specifiedRoles }, config) => {
+export const syncRoles: SyncRoles = async (
+    { specifiedRoles, dryRun },
+    config,
+) => {
     const specifiedRolesContent = await Promise.all(
         specifiedRoles.map((roles) =>
             getFileContentWithRequire({ file: roles.p }),
         ),
     );
 
-    await syncRolesData({ roles: specifiedRolesContent }, config);
+    await syncRolesData({ roles: specifiedRolesContent, dryRun }, config);
 };

--- a/src/api/roles/roles.ts
+++ b/src/api/roles/roles.ts
@@ -103,7 +103,7 @@ export const getRole: GetRole = async (
 };
 
 export const syncRolesData = async (
-    { roles }: { roles: any[] },
+    { roles, dryRun }: { roles: any[]; dryRun?: boolean },
     config: any,
 ): Promise<SyncResult> => {
     const result: SyncResult = {
@@ -112,6 +112,12 @@ export const syncRolesData = async (
         skipped: [],
         errors: [],
     };
+
+    if (dryRun) {
+        Logger.warning(
+            "[dry-run] Role sync will only read remote data and report planned changes.",
+        );
+    }
 
     const space_roles_raw = await getAllRoles(config);
     const space_roles = Array.isArray(space_roles_raw) ? space_roles_raw : [];
@@ -135,20 +141,30 @@ export const syncRolesData = async (
         }
     }
 
-    const updateResults = await Promise.allSettled(
-        rolesToUpdate.map((role) => updateRole(role, config) as any),
-    );
-    updateResults.forEach((r, idx) => {
+    const updateResults = dryRun
+        ? rolesToUpdate.map(() => ({ status: "fulfilled" as const }))
+        : await Promise.allSettled(
+              rolesToUpdate.map((role) => updateRole(role, config) as any),
+          );
+    updateResults.forEach((r: any, idx) => {
         const name = String(rolesToUpdate[idx]?.role ?? "unknown");
+        if (dryRun) {
+            Logger.warning(`[dry-run] Would update role '${name}'.`);
+        }
         if (r.status === "fulfilled") result.updated.push(name);
         else result.errors.push({ name, message: String(r.reason) });
     });
 
-    const createResults = await Promise.allSettled(
-        rolesToCreate.map((role) => createRole(role, config) as any),
-    );
-    createResults.forEach((r, idx) => {
+    const createResults = dryRun
+        ? rolesToCreate.map(() => ({ status: "fulfilled" as const }))
+        : await Promise.allSettled(
+              rolesToCreate.map((role) => createRole(role, config) as any),
+          );
+    createResults.forEach((r: any, idx) => {
         const name = String(rolesToCreate[idx]?.role ?? "unknown");
+        if (dryRun) {
+            Logger.warning(`[dry-run] Would create role '${name}'.`);
+        }
         if (r.status === "fulfilled") result.created.push(name);
         else result.errors.push({ name, message: String(r.reason) });
     });

--- a/src/api/roles/roles.types.ts
+++ b/src/api/roles/roles.types.ts
@@ -1,4 +1,5 @@
 import type { OneFileElement } from "../../utils/path-utils.js";
+import type { SyncOptions } from "../sync/sync.types.js";
 import type { RequestBaseConfig } from "../utils/request.js";
 
 export type GetRole = (
@@ -11,11 +12,17 @@ export type CreateRole = (role: any, config: RequestBaseConfig) => void;
 export type UpdateRole = (role: any, config: RequestBaseConfig) => void;
 
 export type SyncRoles = (
-    { specifiedRoles }: { specifiedRoles: OneFileElement[] },
+    {
+        specifiedRoles,
+        dryRun,
+    }: { specifiedRoles: OneFileElement[]; dryRun?: boolean },
     config: RequestBaseConfig,
 ) => Promise<void>;
-export type SyncAllRoles = (config: RequestBaseConfig) => Promise<void>;
+export type SyncAllRoles = (
+    config: RequestBaseConfig,
+    options?: SyncOptions,
+) => Promise<void>;
 export type SyncProvidedRoles = (
-    { roles }: { roles: string[] },
+    { roles, dryRun }: { roles: string[]; dryRun?: boolean },
     config: RequestBaseConfig,
 ) => Promise<void>;

--- a/src/api/sync/sync.types.ts
+++ b/src/api/sync/sync.types.ts
@@ -7,6 +7,10 @@ export interface SyncResult {
     errors: SyncError[];
 }
 
+export interface SyncOptions {
+    dryRun?: boolean;
+}
+
 /**
  * Progress event emitted during sync operations
  */

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -32,6 +32,7 @@ export const syncDescription = `
     FLAGS
         --all           - Sync all components, roles, datasources                            [components, roles, datasources]
         --presets       - Pass it, if u want to sync also with presets (will take longer)    [components only]
+        --dry-run       - Preview planned changes without making writes                      [components, roles, datasources, plugins, content]
         
         --yes           - Skip ask for confirmation (dangerous, but useful in CI/CD)         [content only]
         --from          - Space ID from which you want to sync content                       [content only]
@@ -41,13 +42,16 @@ export const syncDescription = `
     
     EXAMPLES
         $ sb-mig sync components --all
+        $ sb-mig sync components --all --dry-run
         $ sb-mig sync components --all --presets
         $ sb-mig sync components accordion accordion-item
         $ sb-mig sync components accordion accordion-item --presets
         
         $ sb-mig sync roles --all
+        $ sb-mig sync roles --all --dry-run
         
         $ sb-mig sync datasources --all
+        $ sb-mig sync datasources --all --dry-run
         
         $ sb-mig sync plugins my-awesome-plugin - (you have to be in catalog which has ./dist/export.js file with compiled plugin)
         

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -37,6 +37,7 @@ export const sync = async (props: CLIOptions) => {
     const { input, flags } = props;
 
     const command = input[1];
+    const dryRun = Boolean(flags["dryRun"]);
     const rules = {
         all: ["all"],
         assets: ["assets"],
@@ -54,6 +55,7 @@ export const sync = async (props: CLIOptions) => {
         "presets",
         "packageName",
         "yes",
+        "dryRun",
     ]);
 
     switch (command) {
@@ -67,12 +69,14 @@ export const sync = async (props: CLIOptions) => {
 
                 const presets = flags["presets"] || false;
 
-                await syncAllComponents(presets, apiConfig);
+                await syncAllComponents(presets, apiConfig, { dryRun });
 
-                await setComponentDefaultPreset({
-                    presets: Boolean(flags.presets),
-                    apiConfig,
-                });
+                if (!dryRun) {
+                    await setComponentDefaultPreset({
+                        presets: Boolean(flags.presets),
+                        apiConfig,
+                    });
+                }
             }
 
             if (isIt("empty")) {
@@ -84,13 +88,16 @@ export const sync = async (props: CLIOptions) => {
                     componentsToSync,
                     flags.packageName,
                     apiConfig,
+                    { dryRun },
                 );
 
-                await setComponentDefaultPreset({
-                    presets: Boolean(flags.presets),
-                    componentsToSync,
-                    apiConfig,
-                });
+                if (!dryRun) {
+                    await setComponentDefaultPreset({
+                        presets: Boolean(flags.presets),
+                        componentsToSync,
+                        apiConfig,
+                    });
+                }
             }
 
             if (isIt("allWithSSOT")) {
@@ -99,17 +106,24 @@ export const sync = async (props: CLIOptions) => {
                 );
                 const presets = flags["presets"] || false;
 
-                await askForConfirmation(
-                    "Are you sure you want to use Single Source of truth? It will remove all your components added in GUI and replace them 1 to 1 with code versions.",
-                    async () => {
-                        await removeAllComponents(apiConfig);
-                        await syncAllComponents(presets, apiConfig);
-                    },
-                    () => {
-                        Logger.success("Syncing components aborted.");
-                    },
-                    flags["yes"],
-                );
+                if (dryRun) {
+                    await syncAllComponents(presets, apiConfig, {
+                        dryRun,
+                        ssot: true,
+                    });
+                } else {
+                    await askForConfirmation(
+                        "Are you sure you want to use Single Source of truth? It will remove all your components added in GUI and replace them 1 to 1 with code versions.",
+                        async () => {
+                            await removeAllComponents(apiConfig);
+                            await syncAllComponents(presets, apiConfig);
+                        },
+                        () => {
+                            Logger.success("Syncing components aborted.");
+                        },
+                        flags["yes"],
+                    );
+                }
             }
 
             break;
@@ -117,28 +131,35 @@ export const sync = async (props: CLIOptions) => {
             if (isIt("all")) {
                 Logger.log("Syncing all roles...");
 
-                await syncAllRoles(apiConfig);
+                await syncAllRoles(apiConfig, { dryRun });
             }
 
             if (isIt("empty")) {
                 Logger.log("Syncing provided roles...");
                 const rolesToSync = unpackElements(input);
 
-                await syncProvidedRoles({ roles: rolesToSync }, apiConfig);
+                await syncProvidedRoles(
+                    { roles: rolesToSync, dryRun },
+                    apiConfig,
+                );
             }
             break;
         case SYNC_COMMANDS.datasources:
             if (isIt("all")) {
-                Logger.log("Syncing all datasources with extension...");
-                await syncAllDatasources(apiConfig);
+                Logger.log(
+                    `${dryRun ? "[dry-run] " : ""}Syncing all datasources with extension...`,
+                );
+                await syncAllDatasources(apiConfig, { dryRun });
             }
 
             if (!flags["all"]) {
-                Logger.log("Syncing provided datasources with extension...");
+                Logger.log(
+                    `${dryRun ? "[dry-run] " : ""}Syncing provided datasources with extension...`,
+                );
                 const datasourcesToSync = unpackElements(input);
 
                 await syncProvidedDatasources(
-                    { datasources: datasourcesToSync },
+                    { datasources: datasourcesToSync, dryRun },
                     apiConfig,
                 );
             }
@@ -167,58 +188,82 @@ export const sync = async (props: CLIOptions) => {
             if (syncDirection) {
                 if (isIt("all")) {
                     if (syncDirection !== "fromSpaceToFile") {
-                        await askForConfirmation(
-                            "Are you sure you want to delete all content (stories) in your space and then apply new ones ?",
-                            async () => {
-                                Logger.warning(
-                                    "Deleting all stories in your space and then applying migrated ones...",
-                                );
+                        if (dryRun) {
+                            await syncContent(
+                                {
+                                    type: "stories",
+                                    transmission: { from, to },
+                                    syncDirection,
+                                    dryRun,
+                                },
+                                apiConfig,
+                            );
 
-                                // Backup all stories to file
-                                await syncContent(
-                                    {
-                                        type: "stories",
-                                        transmission: {
-                                            from: to,
-                                            to: `${to}_stories-backup`,
+                            await syncContent(
+                                {
+                                    type: "assets",
+                                    transmission: { from, to },
+                                    syncDirection,
+                                    dryRun,
+                                },
+                                apiConfig,
+                            );
+                        } else {
+                            await askForConfirmation(
+                                "Are you sure you want to delete all content (stories) in your space and then apply new ones ?",
+                                async () => {
+                                    Logger.warning(
+                                        "Deleting all stories in your space and then applying migrated ones...",
+                                    );
+
+                                    // Backup all stories to file
+                                    await syncContent(
+                                        {
+                                            type: "stories",
+                                            transmission: {
+                                                from: to,
+                                                to: `${to}_stories-backup`,
+                                            },
+                                            syncDirection: "fromSpaceToFile",
                                         },
-                                        syncDirection: "fromSpaceToFile",
-                                    },
-                                    apiConfig,
-                                );
+                                        apiConfig,
+                                    );
 
-                                // Remove all stories from 'to' space
-                                await managementApi.stories.removeAllStories({
-                                    ...apiConfig,
-                                    spaceId: to,
-                                });
+                                    // Remove all stories from 'to' space
+                                    await managementApi.stories.removeAllStories(
+                                        {
+                                            ...apiConfig,
+                                            spaceId: to,
+                                        },
+                                    );
 
-                                // Sync stories from 'from' space to 'to' space
-                                await syncContent(
-                                    {
-                                        type: "stories",
-                                        transmission: { from, to },
-                                        syncDirection,
-                                    },
-                                    apiConfig,
-                                );
+                                    // Sync stories from 'from' space to 'to' space
+                                    await syncContent(
+                                        {
+                                            type: "stories",
+                                            transmission: { from, to },
+                                            syncDirection,
+                                        },
+                                        apiConfig,
+                                    );
 
-                                await syncContent(
-                                    {
-                                        type: "assets",
-                                        transmission: { from, to },
-                                        syncDirection,
-                                    },
-                                    apiConfig,
-                                );
-                            },
-                            () => {
-                                Logger.success(
-                                    "Stories not deleted, exiting the program...",
-                                );
-                            },
-                            flags["yes"],
-                        );
+                                    await syncContent(
+                                        {
+                                            type: "assets",
+                                            transmission: { from, to },
+                                            syncDirection,
+                                        },
+                                        apiConfig,
+                                    );
+                                },
+                                () => {
+                                    Logger.success(
+                                        "Stories not deleted, exiting the program...",
+                                    );
+                                },
+                                flags["yes"],
+                            );
+                        }
                     } else {
                         await syncContent(
                             {
@@ -226,6 +271,7 @@ export const sync = async (props: CLIOptions) => {
                                 transmission: { from, to },
                                 syncDirection,
                                 filename: flags.to,
+                                dryRun,
                             },
                             apiConfig,
                         );
@@ -235,6 +281,7 @@ export const sync = async (props: CLIOptions) => {
                                 type: "assets",
                                 transmission: { from, to },
                                 syncDirection,
+                                dryRun,
                             },
                             apiConfig,
                         );
@@ -249,6 +296,7 @@ export const sync = async (props: CLIOptions) => {
                             type: "assets",
                             transmission: { from, to },
                             syncDirection,
+                            dryRun,
                         },
                         apiConfig,
                     );
@@ -258,50 +306,64 @@ export const sync = async (props: CLIOptions) => {
                     );
 
                     if (syncDirection !== "fromSpaceToFile") {
-                        await askForConfirmation(
-                            "Are you sure you want to delete all stories in your space and then apply new ones ?",
-                            async () => {
-                                Logger.warning(
-                                    "Deleting all stories in your space and then applying test ones...",
-                                );
+                        if (dryRun) {
+                            await syncContent(
+                                {
+                                    type: "stories",
+                                    transmission: { from, to },
+                                    syncDirection,
+                                    dryRun,
+                                },
+                                apiConfig,
+                            );
+                        } else {
+                            await askForConfirmation(
+                                "Are you sure you want to delete all stories in your space and then apply new ones ?",
+                                async () => {
+                                    Logger.warning(
+                                        "Deleting all stories in your space and then applying test ones...",
+                                    );
 
-                                // Backup all stories to file
-                                await syncContent(
-                                    {
-                                        type: "stories",
-                                        transmission: {
-                                            from: to,
-                                            to: `${to}_stories-backup`,
+                                    // Backup all stories to file
+                                    await syncContent(
+                                        {
+                                            type: "stories",
+                                            transmission: {
+                                                from: to,
+                                                to: `${to}_stories-backup`,
+                                            },
+                                            syncDirection: "fromSpaceToFile",
                                         },
-                                        syncDirection: "fromSpaceToFile",
-                                    },
-                                    apiConfig,
-                                );
+                                        apiConfig,
+                                    );
 
-                                // Remove all stories from 'to' space
-                                await managementApi.stories.removeAllStories({
-                                    ...apiConfig,
-                                    spaceId: to,
-                                });
+                                    // Remove all stories from 'to' space
+                                    await managementApi.stories.removeAllStories(
+                                        {
+                                            ...apiConfig,
+                                            spaceId: to,
+                                        },
+                                    );
 
-                                //
-                                // Sync stories to 'to' space
-                                await syncContent(
-                                    {
-                                        type: "stories",
-                                        transmission: { from, to },
-                                        syncDirection,
-                                    },
-                                    apiConfig,
-                                );
-                            },
-                            () => {
-                                Logger.success(
-                                    "Stories not deleted, exiting the program...",
-                                );
-                            },
-                            flags["yes"],
-                        );
+                                    //
+                                    // Sync stories to 'to' space
+                                    await syncContent(
+                                        {
+                                            type: "stories",
+                                            transmission: { from, to },
+                                            syncDirection,
+                                        },
+                                        apiConfig,
+                                    );
+                                },
+                                () => {
+                                    Logger.success(
+                                        "Stories not deleted, exiting the program...",
+                                    );
+                                },
+                                flags["yes"],
+                            );
+                        }
                     } else {
                         // Sync stories to 'to' space
                         await syncContent(
@@ -309,6 +371,7 @@ export const sync = async (props: CLIOptions) => {
                                 type: "stories",
                                 transmission: { from, to },
                                 syncDirection,
+                                dryRun,
                             },
                             apiConfig,
                         );
@@ -337,6 +400,7 @@ export const sync = async (props: CLIOptions) => {
                 await managementApi.plugins.syncProvidedPlugins(
                     {
                         plugins: pluginsToSync,
+                        dryRun,
                     },
                     apiConfig,
                 );

--- a/src/cli/datasources/sync.ts
+++ b/src/cli/datasources/sync.ts
@@ -16,7 +16,7 @@ export const syncProvidedDatasources: SyncProvidedDatasources = async (
     args,
     config,
 ) => {
-    const { datasources } = args;
+    const { datasources, dryRun } = args;
 
     const allLocalDatasources = await discoverManyDatasources({
         scope: SCOPE.local,
@@ -39,12 +39,18 @@ export const syncProvidedDatasources: SyncProvidedDatasources = async (
     await managementApi.datasources.syncDatasources(
         {
             providedDatasources: [...local, ...external],
+            dryRun,
         },
         config,
     );
 };
 
-export const syncAllDatasources: SyncAllDatasources = async (config) => {
+export const syncAllDatasources: SyncAllDatasources = async (
+    config,
+    args = {},
+) => {
+    const { dryRun } = args;
+
     const allLocalDatasources = await discoverDatasources({
         scope: SCOPE.local,
         type: LOOKUP_TYPE.fileName,
@@ -63,6 +69,7 @@ export const syncAllDatasources: SyncAllDatasources = async (config) => {
     await managementApi.datasources.syncDatasources(
         {
             providedDatasources: [...local, ...external],
+            dryRun,
         },
         config,
     );

--- a/src/cli/roles/sync.ts
+++ b/src/cli/roles/sync.ts
@@ -12,7 +12,7 @@ import {
     SCOPE,
 } from "../utils/discover.js";
 
-export const syncAllRoles: SyncAllRoles = async (config) => {
+export const syncAllRoles: SyncAllRoles = async (config, options = {}) => {
     // #1: discover all external .roles.sb.js files
     const allLocalSbComponentsSchemaFiles = await discoverRoles({
         scope: SCOPE.local,
@@ -31,13 +31,13 @@ export const syncAllRoles: SyncAllRoles = async (config) => {
 
     // #4: sync - do all stuff already done (groups resolving, and so on)
     await managementApi.roles.syncRoles(
-        { specifiedRoles: [...local, ...external] },
+        { specifiedRoles: [...local, ...external], dryRun: options.dryRun },
         config,
     );
 };
 
 export const syncProvidedRoles: SyncProvidedRoles = async (
-    { roles }: { roles: string[] },
+    { roles, dryRun },
     config,
 ) => {
     // #1: discover all external .sb.js files
@@ -60,7 +60,7 @@ export const syncProvidedRoles: SyncProvidedRoles = async (
 
     // #4: sync - do all stuff already done (groups resolving, and so on)
     await managementApi.roles.syncRoles(
-        { specifiedRoles: [...local, ...external] },
+        { specifiedRoles: [...local, ...external], dryRun },
         config,
     );
 };


### PR DESCRIPTION
## Summary
- add consistent `--dry-run` support across sync components, datasources, roles, plugins, stories, and assets
- centralize API v2 sync dry-run behavior through the shared core sync paths
- add dry-run tests for components, datasources, roles, and plugins
- fix staged test type resolution for `@storyblok/react` in the test tsconfig

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit`
- pre-commit lint-staged checks during commit

## Notes
- left unrelated local changes to `package-lock.json` and `src/cli/commands/debug.ts` out of the commit