### PR TITLE
fix: improve datasource sync diagnostics

### DIFF
--- a/__tests__/api/datasource-entry-errors.test.ts
+++ b/__tests__/api/datasource-entry-errors.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createDatasourceEntry } from "../../src/api/datasources/datasource-entries.js";
+import {
+    createDatasource,
+    updateDatasource,
+} from "../../src/api/datasources/datasources.js";
+import Logger from "../../src/utils/logger.js";
+import { createMockApiConfig } from "../mocks/storyblokClient.mock.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+describe("datasource API error logging", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("logs entry create failures with entry name and Storyblok response details", async () => {
+        const config = createMockApiConfig();
+        config.sbApi.post.mockRejectedValue({
+            response: {
+                status: 422,
+                statusText: "Unprocessable Entity",
+                data: {
+                    message: "Validation failed",
+                    errors: { name: ["has already been taken"] },
+                },
+            },
+        });
+
+        await createDatasourceEntry(
+            {
+                data: {
+                    datasource: {
+                        id: 123,
+                        name: "colors-theme-dark",
+                    },
+                },
+                datasourceEntry: {
+                    name: "color-brand-primary",
+                    value: "#006BD6",
+                },
+            },
+            config,
+        );
+
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Unable to create datasource entry 'color-brand-primary'",
+            ),
+        );
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining("status: 422 Unprocessable Entity"),
+        );
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining("message: Validation failed"),
+        );
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'errors: {"name":["has already been taken"]}',
+            ),
+        );
+    });
+
+    it("logs datasource create failures with datasource name and response details", async () => {
+        const config = createMockApiConfig();
+        config.sbApi.post.mockRejectedValue({
+            response: {
+                status: 409,
+                data: {
+                    error: "Datasource slug already exists",
+                },
+            },
+        });
+
+        await createDatasource(
+            {
+                datasource: {
+                    name: "colors-theme-dark",
+                    slug: "colors-theme-dark",
+                    dimensions: [],
+                    datasource_entries: [],
+                },
+            },
+            config,
+        );
+
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Unable to create datasource 'colors-theme-dark'",
+            ),
+        );
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining("status: 409"),
+        );
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining("error: Datasource slug already exists"),
+        );
+    });
+
+    it("logs datasource update failures with datasource id and response details", async () => {
+        const config = createMockApiConfig();
+        config.sbApi.put.mockRejectedValue(new Error("Network unavailable"));
+
+        await updateDatasource(
+            {
+                datasource: {
+                    name: "colors-theme-dark",
+                    slug: "colors-theme-dark",
+                    dimensions: [],
+                },
+                datasourceToBeUpdated: {
+                    id: 123,
+                    dimensions: [],
+                },
+            },
+            config,
+        );
+
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "Unable to update datasource 'colors-theme-dark' with id '123'",
+            ),
+        );
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.stringContaining("message: Network unavailable"),
+        );
+    });
+});

--- a/__tests__/api/datasource-entry-errors.test.ts
+++ b/__tests__/api/datasource-entry-errors.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createDatasourceEntry } from "../../src/api/datasources/datasource-entries.js";
+import {
+    createDatasourceEntry,
+    getDatasourceEntries,
+} from "../../src/api/datasources/datasource-entries.js";
 import {
     createDatasource,
     updateDatasource,
@@ -131,6 +134,77 @@ describe("datasource API error logging", () => {
         );
         expect(Logger.error).toHaveBeenCalledWith(
             expect.stringContaining("message: Network unavailable"),
+        );
+    });
+});
+
+describe("datasource entry fetching", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("fetches all datasource entry pages", async () => {
+        const config = createMockApiConfig();
+
+        config.sbApi.get.mockImplementation((path: string, params: any) => {
+            if (path.includes("datasource_entries")) {
+                const entriesByPage: Record<number, any[]> = {
+                    1: [{ id: 1, name: "first", value: "first" }],
+                    2: [{ id: 2, name: "second", value: "second" }],
+                };
+
+                return Promise.resolve({
+                    data: {
+                        datasource_entries:
+                            entriesByPage[params.page as number] ?? [],
+                    },
+                    total: 2,
+                    perPage: 1,
+                });
+            }
+
+            return Promise.resolve({
+                data: {
+                    datasources: [
+                        {
+                            id: 123,
+                            name: "colors-theme-dark",
+                            slug: "colors-theme-dark",
+                            dimensions: [],
+                        },
+                    ],
+                },
+                total: 1,
+                perPage: 100,
+            });
+        });
+
+        const result = await getDatasourceEntries(
+            { datasourceName: "colors-theme-dark" },
+            config,
+        );
+
+        expect(result).toEqual({
+            datasource_entries: [
+                { id: 1, name: "first", value: "first" },
+                { id: 2, name: "second", value: "second" },
+            ],
+        });
+        expect(config.sbApi.get).toHaveBeenCalledWith(
+            "spaces/12345/datasource_entries/",
+            expect.objectContaining({
+                datasource_id: 123,
+                page: 1,
+                per_page: 100,
+            }),
+        );
+        expect(config.sbApi.get).toHaveBeenCalledWith(
+            "spaces/12345/datasource_entries/",
+            expect.objectContaining({
+                datasource_id: 123,
+                page: 2,
+                per_page: 100,
+            }),
         );
     });
 });

--- a/src/api/datasources/datasource-entries.ts
+++ b/src/api/datasources/datasource-entries.ts
@@ -12,6 +12,7 @@ import chalk from "chalk";
 
 import Logger from "../../utils/logger.js";
 import { isObjectEmpty } from "../../utils/object-utils.js";
+import { getAllItemsWithPagination } from "../utils/request.js";
 
 import { getDatasource } from "./datasources.js";
 import { formatDatasourceApiError } from "./error-formatting.js";
@@ -77,19 +78,25 @@ export const getDatasourceEntries: GetDatasourceEntries = async (
     const data = await getDatasource({ datasourceName }, config); // TODO: maybe this step is not needed, i think we can retrieve entries directly using slug (but using delivery api, not management)
 
     if (data) {
-        return sbApi
-            .get(`spaces/${spaceId}/datasource_entries/`, {
-                datasource_id: data[0].id,
-            } as any)
-            .then(async (response: any) => {
-                Logger.success(
-                    `Datasource Entries for '${datasourceName}' datasource successfully retrieved.`,
-                );
-                const { data } = response;
-                return data;
-            })
-            .catch((err) => Logger.error(err));
+        const datasourceEntries = await getAllItemsWithPagination({
+            apiFn: ({ per_page, page }) =>
+                sbApi.get(`spaces/${spaceId}/datasource_entries/`, {
+                    datasource_id: data[0].id,
+                    per_page,
+                    page,
+                } as any),
+            params: {},
+            itemsKey: "datasource_entries",
+        });
+
+        Logger.success(
+            `Datasource Entries for '${datasourceName}' datasource successfully retrieved.`,
+        );
+
+        return { datasource_entries: datasourceEntries };
     }
+
+    return { datasource_entries: [] };
 };
 
 export const createDatasourceEntries: CreateDatasourceEntries = (

--- a/src/api/datasources/datasource-entries.ts
+++ b/src/api/datasources/datasource-entries.ts
@@ -14,6 +14,7 @@ import Logger from "../../utils/logger.js";
 import { isObjectEmpty } from "../../utils/object-utils.js";
 
 import { getDatasource } from "./datasources.js";
+import { formatDatasourceApiError } from "./error-formatting.js";
 
 const _decorateWithDimensions: _DecorateWithDimensions = async (
     args,
@@ -173,7 +174,7 @@ const _createDatasourceEntry: _CreateDatasourceEntry = (args, config) => {
                 console.log(err);
             }
             Logger.error(
-                `Unable to create datasource entry in ${currentDatasource.datasource.name} datasource.`,
+                `Unable to create datasource entry '${finalDatasource_entry.name}' in ${currentDatasource.datasource.name} datasource. Value: '${finalDatasource_entry.value}'. ${formatDatasourceApiError(err)}`,
             );
         });
 };
@@ -237,7 +238,7 @@ const _updateDatasourceEntry: _UpdateDatasourceEntry = (args, config) => {
                 console.log(err);
             }
             Logger.error(
-                `Unable to update datasource entry in ${currentDatasource.datasource.name} datasource.`,
+                `Unable to update datasource entry '${finalDatasource_entry.name}' in ${currentDatasource.datasource.name} datasource. Value: '${finalDatasource_entry.value}'. ${formatDatasourceApiError(err)}`,
             );
         });
 };

--- a/src/api/datasources/datasources.ts
+++ b/src/api/datasources/datasources.ts
@@ -14,6 +14,7 @@ import {
     createDatasourceEntries,
     getDatasourceEntries,
 } from "./datasource-entries.js";
+import { formatDatasourceApiError } from "./error-formatting.js";
 
 // GET
 export const getAllDatasources: GetAllDatasources = (config) => {
@@ -102,7 +103,11 @@ export const createDatasource: CreateDatasource = (args, config) => {
                 datasource_entries: datasource.datasource_entries,
             };
         })
-        .catch((err) => Logger.error(err));
+        .catch((err) =>
+            Logger.error(
+                `Unable to create datasource '${datasource.name}' with slug '${datasource.slug}'. ${formatDatasourceApiError(err)}`,
+            ),
+        );
 };
 
 export const updateDatasource: UpdateDatasource = (args, config) => {
@@ -145,7 +150,11 @@ export const updateDatasource: UpdateDatasource = (args, config) => {
                 datasource_entries: datasource.datasource_entries,
             };
         })
-        .catch((err) => Logger.error(err));
+        .catch((err) =>
+            Logger.error(
+                `Unable to update datasource '${datasource.name}' with id '${datasourceToBeUpdated.id}'. ${formatDatasourceApiError(err)}`,
+            ),
+        );
 };
 
 // File-based sync wrapper lives in `datasources.sync.ts` to keep this module CJS-safe.

--- a/src/api/datasources/error-formatting.ts
+++ b/src/api/datasources/error-formatting.ts
@@ -1,0 +1,36 @@
+export const formatDatasourceApiError = (err: any) => {
+    const details: string[] = [];
+    const status = err?.response?.status;
+    const statusText = err?.response?.statusText;
+    const responseData = err?.response?.data;
+
+    if (status || statusText) {
+        details.push(
+            `status: ${[status, statusText].filter(Boolean).join(" ")}`,
+        );
+    }
+
+    if (responseData?.message) {
+        details.push(`message: ${responseData.message}`);
+    }
+
+    if (responseData?.error) {
+        details.push(`error: ${responseData.error}`);
+    }
+
+    if (responseData?.errors) {
+        details.push(
+            `errors: ${
+                typeof responseData.errors === "string"
+                    ? responseData.errors
+                    : JSON.stringify(responseData.errors)
+            }`,
+        );
+    }
+
+    if (!details.length && err?.message) {
+        details.push(`message: ${err.message}`);
+    }
+
+    return details.length ? details.join("; ") : String(err);
+};


### PR DESCRIPTION
## Summary
- include Storyblok response details when datasource or datasource entry sync writes fail
- fetch all remote datasource entry pages before matching local entries
- prevent existing entries beyond the first page from being treated as missing and recreated

## Validation
- npm run typecheck
- npm run lint
- npm run test:unit