### PR TITLE
fix(windows): resolve path separator bugs breaking sync on Windows

### DIFF
--- a/__tests__/build-on-the-fly.test.ts
+++ b/__tests__/build-on-the-fly.test.ts
@@ -3,25 +3,56 @@ import { describe, it, expect } from "vitest";
 import { extractComponentName as _extractComponentName } from "../src/utils/path-utils.js";
 
 describe("Build Typescript on-the-fly", () => {
-    if (process.platform === "win32") {
-        it("WINDOWS: _extractComponentName return OK filename (removes .sb.ts and beginning)", () => {
-            const windowsFilePath = "C:/Users/username/Desktop/example.sb.ts"; // this will be already from glob, which is unix slash not windows slash
-            expect(_extractComponentName(windowsFilePath)).toBe("example.sb");
+    // These tests are platform-independent: extractComponentName must handle
+    // both `\` and `/` regardless of the runtime OS, because glob v11 returns
+    // native-separator paths on Windows even when given a POSIX-style pattern.
+    describe("extractComponentName", () => {
+        it("handles Windows backslash paths", () => {
+            expect(
+                _extractComponentName(
+                    "C:\\Users\\username\\Desktop\\example.sb.ts",
+                ),
+            ).toBe("example.sb");
+            expect(
+                _extractComponentName(
+                    "C:\\Users\\me\\project\\src\\components\\hero.sb.ts",
+                ),
+            ).toBe("hero.sb");
         });
-    } else if (process.platform === "darwin" || process.platform === "linux") {
-        it("MAC OS / UBUNTU: _extractComponentName return OK filename (removes .sb.ts and beginning)", () => {
-            const filePath =
-                "/Users/marckraw/Projects/amazing-project/src/components/card.sb.ts";
-            const filePath2 =
-                "/Users/marckraw/Projects/amazing-project/src/components/something-amazing.sb.ts";
-            const filePath3 =
-                "/Users/marckraw/Projects/amazing-project/src/components/good.super.sb.ts";
 
-            expect(_extractComponentName(filePath)).toBe("card.sb");
-            expect(_extractComponentName(filePath2)).toBe(
-                "something-amazing.sb",
-            );
-            expect(_extractComponentName(filePath3)).toBe("good.super.sb");
+        it("handles Windows forward-slash paths (drive-letter)", () => {
+            expect(
+                _extractComponentName("C:/Users/username/Desktop/example.sb.ts"),
+            ).toBe("example.sb");
         });
-    }
+
+        it("handles POSIX forward-slash paths", () => {
+            expect(
+                _extractComponentName(
+                    "/Users/marckraw/Projects/amazing-project/src/components/card.sb.ts",
+                ),
+            ).toBe("card.sb");
+            expect(
+                _extractComponentName(
+                    "/Users/marckraw/Projects/amazing-project/src/components/something-amazing.sb.ts",
+                ),
+            ).toBe("something-amazing.sb");
+        });
+
+        it("preserves dots in the file name and only strips trailing .ts", () => {
+            expect(
+                _extractComponentName(
+                    "/Users/marckraw/Projects/amazing-project/src/components/good.super.sb.ts",
+                ),
+            ).toBe("good.super.sb");
+            // .ts in the middle of the name must not be stripped
+            expect(_extractComponentName("/foo/bar/x.tsx.sb.ts")).toBe(
+                "x.tsx.sb",
+            );
+        });
+
+        it("handles bare file names (no separator)", () => {
+            expect(_extractComponentName("hero.sb.ts")).toBe("hero.sb");
+        });
+    });
 });

--- a/src/api-v2/discover/discover.ts
+++ b/src/api-v2/discover/discover.ts
@@ -1,5 +1,5 @@
 import { readdir, stat, readFile, realpath } from "fs/promises";
-import { join, resolve } from "path";
+import { join, resolve, sep } from "path";
 import { pathToFileURL } from "url";
 
 export interface DiscoveredResource {
@@ -123,9 +123,9 @@ async function isWithinProject(
         // Resolve both paths to handle symlinks
         const resolvedTarget = await realpath(targetPath);
         const resolvedRoot = await realpath(projectRoot);
-        // Check if target is within project root
+        // Use the platform separator so this works on Windows (`\`) and POSIX (`/`).
         return (
-            resolvedTarget.startsWith(resolvedRoot + "/") ||
+            resolvedTarget.startsWith(resolvedRoot + sep) ||
             resolvedTarget === resolvedRoot
         );
     } catch {

--- a/src/api-v2/precompile/precompile.ts
+++ b/src/api-v2/precompile/precompile.ts
@@ -34,13 +34,16 @@ export interface PrecompileResult {
 }
 
 /**
- * Extract the component name from a file path
+ * Extract the component name from a file path.
+ * Handles both POSIX (`/`) and Windows (`\`) separators because glob v11
+ * and node's `fs` APIs return native paths on Windows.
+ *
  * e.g., "/path/to/my-component.sb.ts" -> "my-component.sb"
+ *       "C:\\path\\to\\my-component.sb.ts" -> "my-component.sb"
  */
 export const extractComponentName = (filePath: string): string => {
-    const separator = "/";
-    const parts = filePath.split(separator);
-    const lastElement = parts[parts.length - 1] as string;
+    const normalized = filePath.replace(/\\/g, "/");
+    const lastElement = normalized.substring(normalized.lastIndexOf("/") + 1);
     return lastElement.replace(/\.ts$/, "");
 };
 

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -8,19 +8,22 @@ import path from "path";
  * Extracts the component name from a file path.
  * Used for naming compiled output files from TypeScript sources.
  *
- * @param filePath - Full path to the component file (always uses Unix-style separators from glob)
- * @returns Component name without the .ts extension
+ * Handles both POSIX (`/`) and Windows (`\`) separators because glob v11
+ * returns native paths on Windows.
+ *
+ * @param filePath - Full path to the component file
+ * @returns Component name without the trailing .ts extension
  *
  * @example
- * _extractComponentName("/Users/project/src/hero.sb.ts") // => "hero.sb"
- * _extractComponentName("C:/Users/project/src/card.sb.ts") // => "card.sb"
+ * extractComponentName("/Users/project/src/hero.sb.ts") // => "hero.sb"
+ * extractComponentName("C:\\Users\\project\\src\\card.sb.ts") // => "card.sb"
  */
 export const extractComponentName = (filePath: string): string => {
-    const separator = "/"; // glob always returns unix-style paths
-    const sP = filePath.split(separator);
-    const lastElement = sP[sP.length - 1] as string;
+    // Normalize to forward slashes so basename works regardless of platform.
+    const normalized = filePath.replace(/\\/g, "/");
+    const lastElement = normalized.substring(normalized.lastIndexOf("/") + 1);
 
-    return lastElement.replaceAll(".ts", "");
+    return lastElement.replace(/\.ts$/, "");
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes `sb-mig sync` failing on Windows with errors like:
```
ENOENT: no such file or directory, mkdir
'C:\Users\...\.next\cache\sb-mig\C:\Users\...\src\components'
```

Two underlying Windows-path bugs:

- **`extractComponentName`** (in both `src/utils/path-utils.ts` and the api-v2 duplicate `src/api-v2/precompile/precompile.ts`) split on hardcoded `"/"`. Glob v11 returns native paths on Windows, so the full input path was treated as the basename. `path.join(cacheDir, fullAbsolutePath + ".cjs")` then concatenated two absolute paths and Rollup could not `mkdir` the bogus parent. Fix: normalize backslashes, take the basename, and only strip a trailing `.ts`.
- **`isWithinProject`** (in `src/api-v2/discover/discover.ts`) compared paths with `+ "/"`, which never matched on Windows where `realpath` returns paths with `\`. Sub-directory scans were silently skipped. Fix: use `path.sep`.

## Changes

- `src/utils/path-utils.ts` — fix `extractComponentName` for both separators
- `src/api-v2/precompile/precompile.ts` — same fix on the api-v2 duplicate
- `src/api-v2/discover/discover.ts` — `isWithinProject` uses `path.sep`
- `__tests__/build-on-the-fly.test.ts` — replace platform-gated tests with platform-independent cases covering `\`, `/`, drive letters, internal dots, and bare filenames

## Test plan

- [x] `npx vitest run` — 386 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual verification on Windows with `yarn sb-mig sync components page`

🤖 Generated with [Claude Code](https://claude.com/claude-code)