### PR TITLE
feat: add publish mode for migrations

### DIFF
--- a/__tests__/api/stories-update.test.ts
+++ b/__tests__/api/stories-update.test.ts
@@ -20,6 +20,74 @@ describe("updateStory", () => {
         vi.clearAllMocks();
     });
 
+    it("saves story updates as drafts by default", async () => {
+        const put = vi.fn().mockResolvedValue({
+            data: {
+                story: {
+                    id: "story-1",
+                    name: "Japan",
+                    full_slug: "tours/destinations/japan",
+                },
+            },
+        });
+        const config = {
+            spaceId: "291967263583956",
+            sbApi: {
+                put,
+            },
+        } as any;
+        const content = {
+            id: "story-1",
+            name: "Japan",
+            full_slug: "tours/destinations/japan",
+        };
+
+        await updateStory(content, "story-1", { publish: false }, config);
+
+        expect(put).toHaveBeenCalledWith(
+            "spaces/291967263583956/stories/story-1",
+            {
+                story: content,
+                publish: 0,
+                force_update: 0,
+            },
+        );
+    });
+
+    it("publishes story updates when requested", async () => {
+        const put = vi.fn().mockResolvedValue({
+            data: {
+                story: {
+                    id: "story-1",
+                    name: "Japan",
+                    full_slug: "tours/destinations/japan",
+                },
+            },
+        });
+        const config = {
+            spaceId: "291967263583956",
+            sbApi: {
+                put,
+            },
+        } as any;
+        const content = {
+            id: "story-1",
+            name: "Japan",
+            full_slug: "tours/destinations/japan",
+        };
+
+        await updateStory(content, "story-1", { publish: true }, config);
+
+        expect(put).toHaveBeenCalledWith(
+            "spaces/291967263583956/stories/story-1",
+            {
+                story: content,
+                publish: 1,
+                force_update: 0,
+            },
+        );
+    });
+
     it("logs the failing story slug, space, and Storyblok response", async () => {
         const put = vi.fn().mockRejectedValue({
             status: 422,

--- a/__tests__/flagsParse.test.ts
+++ b/__tests__/flagsParse.test.ts
@@ -116,4 +116,26 @@ describe("isItFactory for parsing flags", () => {
             });
         });
     });
+
+    it("allows publish as a whitelisted migrate option", () => {
+        const rules = {
+            all: ["all", "migrateFrom"],
+            empty: [],
+        };
+        const isIt = isItFactory<keyof typeof rules>(
+            {
+                all: true,
+                migrateFrom: "space",
+                publish: true,
+                migration: "component-migration",
+                from: "1234",
+                to: "987",
+            },
+            rules,
+            ["from", "to", "migration", "publish"],
+        );
+
+        expect(isIt("all")).toBe(true);
+        expect(isIt("empty")).toBe(false);
+    });
 });

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -88,6 +88,7 @@ interface MigrateItems {
         startsWith?: string;
     };
     dryRun?: boolean;
+    publish?: boolean;
     fromFilePath?: string;
     fileName?: string;
     preparedMigrationConfigs?: PreparedMigrationConfig[];
@@ -581,6 +582,7 @@ const savePipelineSummary = async (
         from,
         itemType,
         dryRun,
+        publish,
         migrateFrom,
         fromFilePath,
         pipelineResult,
@@ -590,6 +592,7 @@ const savePipelineSummary = async (
         from: string;
         itemType: "story" | "preset";
         dryRun?: boolean;
+        publish?: boolean;
         migrateFrom: MigrateFrom;
         fromFilePath?: string;
         pipelineResult: MigrationPipelineResult;
@@ -611,6 +614,7 @@ const savePipelineSummary = async (
                     from,
                     fromFilePath: fromFilePath || null,
                 },
+                writeMode: itemType === "story" && publish ? "publish" : "save",
                 totalItems: pipelineResult.totalItems,
                 totalChangedItems: pipelineResult.changedItems.length,
                 steps: pipelineResult.stepReports,
@@ -761,6 +765,7 @@ export const migrateAllComponentsDataInStories = async (
         to,
         filters,
         dryRun,
+        publish,
         fromFilePath,
         fileName,
         migrationComponentAliases,
@@ -803,6 +808,7 @@ export const migrateAllComponentsDataInStories = async (
             to,
             filters,
             dryRun,
+            publish,
             fromFilePath,
             fileName,
             preparedMigrationConfigs,
@@ -820,6 +826,7 @@ export const doTheMigration = async (
         migrationConfigs,
         to,
         dryRun,
+        publish,
         migrateFrom,
         fromFilePath,
         fileName,
@@ -831,6 +838,7 @@ export const doTheMigration = async (
         migrationConfigs?: PreparedMigrationConfig[];
         to: string;
         dryRun?: boolean;
+        publish?: boolean;
         migrateFrom: MigrateFrom;
         fromFilePath?: string;
         fileName?: string;
@@ -931,6 +939,7 @@ export const doTheMigration = async (
             from,
             itemType,
             dryRun,
+            publish,
             migrateFrom,
             fromFilePath,
             pipelineResult,
@@ -967,7 +976,7 @@ export const doTheMigration = async (
             {
                 stories: pipelineResult.changedItems,
                 spaceId: to,
-                options: { publish: false },
+                options: { publish: Boolean(publish) },
             },
             config,
         );
@@ -1044,6 +1053,7 @@ export const migrateProvidedComponentsDataInStories = async (
         componentsToMigrate,
         filters,
         dryRun,
+        publish,
         fromFilePath,
         fileName,
         preparedMigrationConfigs,
@@ -1098,6 +1108,7 @@ export const migrateProvidedComponentsDataInStories = async (
             from,
             to,
             dryRun,
+            publish,
             migrateFrom,
             fromFilePath,
             fileName,

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -101,6 +101,7 @@ export const migrateDescription = `
         --startsWith      - Filter stories by starts_with prefix
         --yes             - Skip ask for confirmation (dangerous, but useful in CI/CD)
         --dry-run         - Preview what would be migrated without making any API changes
+        --publish         - Publish changed stories immediately after migration. Default: save draft. [content only]
         --fileName        - Stable base name for migration output files (disables timestamp suffix for migration artifacts)
 
     EXAMPLES
@@ -110,6 +111,7 @@ export const migrateDescription = `
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration colorPickerModeValues --migrationComponentAlias colorPickerModeValues:sb-section=sb-tour-page-section --migrationComponents colorPickerModeValues:sb-section,sb-tour-page-section
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --withSlug blog/home --withSlug docs/getting-started
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --startsWith blog/
+        $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --publish --yes
         $ sb-mig migrate content --all --from 12345 --to 12345 --migration v3toV4AllMigrations --dry-run --fileName brand-hub-v3-v4-run
         $ sb-mig migrate content --all --migrate-from file --from file-with-stories --to 12345 --migration file-with-migration
         $ sb-mig migrate content --all --migrate-from file --fromFilePath sbmig/migrations/dry-run--123---story-to-migrate__2026-2-9_20-51.json --to 12345 --migration migration-a --migration migration-b

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -64,6 +64,7 @@ export const migrate = async (props: CLIOptions) => {
         "withSlug",
         "startsWith",
         "dryRun",
+        "publish",
         "fileName",
     ]);
 
@@ -91,13 +92,12 @@ export const migrate = async (props: CLIOptions) => {
             const migrationConfigs = normalizeMigrationFlags(
                 flags["migration"] as string | string[] | undefined,
             );
-            const migrationComponentAliases =
-                parseMigrationComponentAliasFlags(
-                    flags["migrationComponentAlias"] as
-                        | string
-                        | string[]
-                        | undefined,
-                );
+            const migrationComponentAliases = parseMigrationComponentAliasFlags(
+                flags["migrationComponentAlias"] as
+                    | string
+                    | string[]
+                    | undefined,
+            );
             const migrationComponentOverrides =
                 parseMigrationComponentOverrideFlags(
                     flags["migrationComponents"] as
@@ -106,6 +106,7 @@ export const migrate = async (props: CLIOptions) => {
                         | undefined,
                 );
             const dryRun = flags["dryRun"] as boolean | undefined;
+            const publish = Boolean(flags["publish"]);
             const fileName = flags["fileName"] as string | undefined;
             const withSlugFlag = flags["withSlug"] as
                 | string
@@ -159,6 +160,7 @@ export const migrate = async (props: CLIOptions) => {
                             migrationComponentOverrides,
                             filters: { withSlug, startsWith },
                             dryRun,
+                            publish,
                             fromFilePath,
                             fileName,
                         },
@@ -197,6 +199,7 @@ export const migrate = async (props: CLIOptions) => {
                             migrationComponentOverrides,
                             filters: { withSlug, startsWith },
                             dryRun,
+                            publish,
                             fromFilePath,
                             fileName,
                         },
@@ -234,13 +237,12 @@ export const migrate = async (props: CLIOptions) => {
             const migrationConfigs = normalizeMigrationFlags(
                 flags["migration"] as string | string[] | undefined,
             );
-            const migrationComponentAliases =
-                parseMigrationComponentAliasFlags(
-                    flags["migrationComponentAlias"] as
-                        | string
-                        | string[]
-                        | undefined,
-                );
+            const migrationComponentAliases = parseMigrationComponentAliasFlags(
+                flags["migrationComponentAlias"] as
+                    | string
+                    | string[]
+                    | undefined,
+            );
             const migrationComponentOverrides =
                 parseMigrationComponentOverrideFlags(
                     flags["migrationComponents"] as
@@ -261,10 +263,17 @@ export const migrate = async (props: CLIOptions) => {
                 fromFallback ||
                 getFrom(flags, apiConfig);
             const to = getTo(flags, apiConfig);
+            const publish = Boolean(flags["publish"]);
 
             if (migrationConfigs.length === 0) {
                 throw new Error(
                     "Missing migration config. Pass exactly one --migration value for presets.",
+                );
+            }
+
+            if (publish) {
+                throw new Error(
+                    "--publish is only supported for 'migrate content'. Presets cannot be published.",
                 );
             }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -97,6 +97,10 @@ app.migrate = () => ({
                 type: "boolean",
                 default: false,
             },
+            publish: {
+                type: "boolean",
+                default: false,
+            },
             fileName: {
                 type: "string",
             },


### PR DESCRIPTION
## Summary
- add a `--publish` flag for `migrate content` so changed stories can be published immediately
- keep draft-save behavior as the default and reject `--publish` for presets
- include migration write mode in the pipeline summary and add tests for publish payload/flag parsing

## Validation
- `npm run typecheck`
- `npm run test:unit`