### PR TITLE
chore(lockfile): align beta package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sb-mig",
-  "version": "5.8.0",
+  "version": "6.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sb-mig",
-      "version": "5.8.0",
+      "version": "6.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-swc": "^0.4.0",


### PR DESCRIPTION
## Summary
- base this branch on the latest `beta` branch
- align the lockfile root package version with `package.json` at `6.0.0-beta.3`
- keep the existing Node 24 and `@rollup/plugin-swc` beta changes intact

## Validation
- `npm run typecheck`
- `npm run test:unit`
- `npm run build`
- `node scripts/package-smoke.mjs /private/tmp/sb-mig-6.0.0-beta.3.tgz`