### PR TITLE
feat(migrate): add JSONL run logs

### DIFF
--- a/__tests__/api/migration-run-log.test.ts
+++ b/__tests__/api/migration-run-log.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildMigrationRunLogRecords,
+    recordsToJsonl,
+} from "../../src/api/data-migration/migration-run-log.js";
+
+describe("migration run log", () => {
+    it("records each update result and the final write summary as JSONL", () => {
+        const records = buildMigrationRunLogRecords({
+            from: "source-space",
+            to: "target-space",
+            itemType: "story",
+            publish: true,
+            dryRun: false,
+            migrateFrom: "space",
+            pipelineResult: {
+                totalItems: 3,
+                finalItems: [],
+                stepReports: [
+                    {
+                        migrationConfig: "carouselToV4",
+                        touchedItems: 1,
+                        totalComponentReplacements: 1,
+                        replacementsByComponent: {
+                            "sb-carousel": 1,
+                        },
+                        maxDepth: 4,
+                        validation: null,
+                    },
+                ],
+                changedItems: [
+                    {
+                        story: {
+                            id: "story-1",
+                            name: "Home",
+                            full_slug: "home",
+                        },
+                    },
+                    {
+                        story: {
+                            id: "story-2",
+                            name: "Broken",
+                            full_slug: "broken",
+                        },
+                    },
+                ],
+            },
+            writeResults: [
+                {
+                    status: "fulfilled",
+                    value: {
+                        ok: true,
+                        id: "story-1",
+                        name: "Home",
+                        slug: "home",
+                    },
+                },
+                {
+                    status: "fulfilled",
+                    value: {
+                        ok: false,
+                        id: "story-2",
+                        name: "Broken",
+                        slug: "broken",
+                        spaceId: "target-space",
+                        status: 422,
+                        response: "The field sb-carousel.content can't be blank",
+                    },
+                },
+            ],
+            writeSummary: {
+                total: 2,
+                successful: 1,
+                failed: 1,
+                failedItems: [
+                    {
+                        ok: false,
+                        id: "story-2",
+                        name: "Broken",
+                        slug: "broken",
+                        spaceId: "target-space",
+                        status: 422,
+                        response: "The field sb-carousel.content can't be blank",
+                    },
+                ],
+            },
+        });
+
+        expect(records).toHaveLength(3);
+        expect(records[0]).toMatchObject({
+            event: "update_success",
+            writeMode: "publish",
+            item: {
+                id: "story-1",
+                slug: "home",
+                spaceId: "target-space",
+            },
+        });
+        expect(records[1]).toMatchObject({
+            event: "update_failed",
+            status: 422,
+            response: "The field sb-carousel.content can't be blank",
+            item: {
+                id: "story-2",
+                slug: "broken",
+                spaceId: "target-space",
+            },
+        });
+        expect(records[2]).toMatchObject({
+            event: "migration_write_summary",
+            writeSummary: {
+                total: 2,
+                successful: 1,
+                failed: 1,
+                failedItems: [
+                    {
+                        id: "story-2",
+                        slug: "broken",
+                        status: 422,
+                    },
+                ],
+            },
+        });
+
+        const parsedLines = recordsToJsonl(records)
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+
+        expect(parsedLines).toHaveLength(3);
+        expect(parsedLines[1].event).toBe("update_failed");
+        expect(parsedLines[2].writeSummary.failed).toBe(1);
+    });
+});

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -32,6 +32,7 @@ import {
     type MigrationComponentOverridesByMigration,
     resolveMigrationComponentsToMigrate,
 } from "./migration-component-scope.js";
+import { saveMigrationRunLog } from "./migration-run-log.js";
 import {
     discoverMigrationValidatorForMigrationFile,
     MigrationValidationFailedError,
@@ -992,6 +993,32 @@ export const doTheMigration = async (
     }
 
     const writeSummary = summarizeMutationWriteResults(writeResults);
+
+    try {
+        await saveMigrationRunLog(
+            {
+                artifactBaseName,
+                useDatestamp,
+                from,
+                to,
+                itemType,
+                dryRun,
+                publish,
+                migrateFrom,
+                fromFilePath,
+                pipelineResult,
+                writeResults,
+                writeSummary,
+            },
+            config,
+        );
+    } catch (error) {
+        Logger.warning(
+            `[MIGRATION] Could not write migration run log: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
 
     if (writeSummary.failed === 0) {
         Logger.success(

--- a/src/api/data-migration/migration-run-log.ts
+++ b/src/api/data-migration/migration-run-log.ts
@@ -1,0 +1,224 @@
+import type {
+    MigrateFrom,
+    MigrationPipelineResult,
+} from "./component-data-migration.js";
+import type {
+    MutationWriteResult,
+    MutationWriteSummary,
+} from "./write-summary.js";
+import type { RequestBaseConfig } from "../utils/request.js";
+
+import { generateDatestamp } from "../../utils/date-utils.js";
+import { createDir, createJsonFile } from "../../utils/files.js";
+import Logger from "../../utils/logger.js";
+
+type MigrationRunLogEvent =
+    | "update_success"
+    | "update_failed"
+    | "migration_write_summary";
+
+export interface MigrationRunLogRecord {
+    timestamp: string;
+    event: MigrationRunLogEvent;
+    runId: string;
+    itemType: "story" | "preset";
+    source: {
+        migrateFrom: MigrateFrom;
+        from: string;
+        fromFilePath: string | null;
+    };
+    target: {
+        to: string;
+    };
+    writeMode: "publish" | "save";
+    dryRun: boolean;
+    migrationConfigs: string[];
+    totalItems: number;
+    totalChangedItems: number;
+    writeSummary?: {
+        total: number;
+        successful: number;
+        failed: number;
+        failedItems: Array<{
+            id?: number | string;
+            name?: string;
+            slug?: string;
+            spaceId?: string;
+            status?: number | string;
+            response?: string | null;
+        }>;
+    };
+    item?: {
+        index: number;
+        id?: number | string;
+        name?: string;
+        slug?: string;
+        spaceId?: string;
+    };
+    status?: number | string | null;
+    response?: string | null;
+    error?: unknown;
+}
+
+interface SaveMigrationRunLogArgs {
+    artifactBaseName: string;
+    useDatestamp: boolean;
+    from: string;
+    to: string;
+    itemType: "story" | "preset";
+    dryRun?: boolean;
+    publish?: boolean;
+    migrateFrom: MigrateFrom;
+    fromFilePath?: string;
+    pipelineResult: MigrationPipelineResult;
+    writeResults: PromiseSettledResult<MutationWriteResult>[];
+    writeSummary: MutationWriteSummary;
+}
+
+const serializeError = (error: unknown): unknown => {
+    if (!error) {
+        return null;
+    }
+
+    if (error instanceof Error) {
+        return {
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+        };
+    }
+
+    try {
+        return JSON.parse(JSON.stringify(error));
+    } catch {
+        return String(error);
+    }
+};
+
+const resolveChangedItemPayload = (item: any) => item?.story || item;
+
+const resolveWriteResultValue = (
+    result: PromiseSettledResult<MutationWriteResult>,
+): MutationWriteResult => {
+    if (result.status === "fulfilled") {
+        return (
+            result.value || {
+                ok: false,
+            }
+        );
+    }
+
+    return {
+        ok: false,
+        error: result.reason,
+    };
+};
+
+export const buildMigrationRunLogRecords = ({
+    from,
+    to,
+    itemType,
+    dryRun,
+    publish,
+    migrateFrom,
+    fromFilePath,
+    pipelineResult,
+    writeResults,
+    writeSummary,
+}: Omit<SaveMigrationRunLogArgs, "artifactBaseName" | "useDatestamp">) => {
+    const timestamp = new Date().toISOString();
+    const runId = `${itemType}-${timestamp}`;
+    const baseRecord = {
+        timestamp,
+        runId,
+        itemType,
+        source: {
+            migrateFrom,
+            from,
+            fromFilePath: fromFilePath || null,
+        },
+        target: {
+            to,
+        },
+        writeMode: itemType === "story" && publish ? "publish" : "save",
+        dryRun: Boolean(dryRun),
+        migrationConfigs: pipelineResult.stepReports.map(
+            (step) => step.migrationConfig,
+        ),
+        totalItems: pipelineResult.totalItems,
+        totalChangedItems: pipelineResult.changedItems.length,
+    } satisfies Omit<MigrationRunLogRecord, "event">;
+
+    const updateRecords: MigrationRunLogRecord[] = writeResults.map(
+        (result, index) => {
+            const value = resolveWriteResultValue(result);
+            const changedItem = resolveChangedItemPayload(
+                pipelineResult.changedItems[index],
+            );
+            const event: MigrationRunLogEvent = value.ok
+                ? "update_success"
+                : "update_failed";
+
+            return {
+                ...baseRecord,
+                event,
+                item: {
+                    index,
+                    id: value.id || changedItem?.id,
+                    name: value.name || changedItem?.name,
+                    slug:
+                        value.slug ||
+                        changedItem?.full_slug ||
+                        changedItem?.slug,
+                    spaceId: value.spaceId || to,
+                },
+                status: value.status || null,
+                response: value.response || null,
+                ...(value.ok ? {} : { error: serializeError(value.error) }),
+            };
+        },
+    );
+
+    const summaryRecord: MigrationRunLogRecord = {
+        ...baseRecord,
+        event: "migration_write_summary",
+        writeSummary: {
+            total: writeSummary.total,
+            successful: writeSummary.successful,
+            failed: writeSummary.failed,
+            failedItems: writeSummary.failedItems.map((item) => ({
+                id: item.id,
+                name: item.name,
+                slug: item.slug,
+                spaceId: item.spaceId,
+                status: item.status,
+                response: item.response || null,
+            })),
+        },
+    };
+
+    return [...updateRecords, summaryRecord];
+};
+
+export const recordsToJsonl = (records: MigrationRunLogRecord[]) =>
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+
+export const saveMigrationRunLog = async (
+    args: SaveMigrationRunLogArgs,
+    config: RequestBaseConfig,
+) => {
+    const { sbmigWorkingDirectory } = config;
+    const { artifactBaseName, useDatestamp, itemType, dryRun } = args;
+    const timestamp = generateDatestamp(new Date());
+    const finalFilename = `${dryRun ? "dry-run--" : ""}${artifactBaseName}---${itemType}-migration-run-log${
+        useDatestamp ? `__${timestamp}` : ""
+    }.jsonl`;
+    const folderPath = `${sbmigWorkingDirectory}/migrations/`;
+    const fullPath = `${folderPath}${finalFilename}`;
+    const records = buildMigrationRunLogRecords(args);
+
+    await createDir(folderPath);
+    await createJsonFile(recordsToJsonl(records), fullPath);
+
+    Logger.success(`Migration run log written to a file:  ${fullPath}`);
+};

--- a/src/api/data-migration/write-summary.ts
+++ b/src/api/data-migration/write-summary.ts
@@ -3,6 +3,9 @@ export interface MutationWriteResult {
     id?: number | string;
     name?: string;
     slug?: string;
+    spaceId?: string;
+    status?: number | string;
+    response?: string | null;
     error?: unknown;
 }
 


### PR DESCRIPTION
## Summary
- add automatic JSONL migration run logs for real migrate write runs
- record per-item update success/failure events, including failed story slug, space, status, and Storyblok response
- append a final migration write summary event with all failed items

## Validation
- npm run test -- __tests__/api/migration-run-log.test.ts
- npm run typecheck
- npm run lint

## Notes
- log artifact is written under `sbmig/migrations/<fileName>---<itemType>-migration-run-log.jsonl`
- left unrelated untracked `__tests__/api/component-data-migration.test.ts` out of the commit