### PR TITLE
fix(migrate): preserve Storyblok publish state

### DIFF
--- a/__tests__/api/migration-run-log.test.ts
+++ b/__tests__/api/migration-run-log.test.ts
@@ -142,4 +142,72 @@ describe("migration run log", () => {
         expect(parsedLines[1].event).toBe("publish_failed");
         expect(parsedLines[2].writeSummary.failed).toBe(1);
     });
+
+    it("records publish skips caused by source publish-state preservation", () => {
+        const records = buildMigrationRunLogRecords({
+            from: "source-space",
+            to: "target-space",
+            itemType: "story",
+            publish: true,
+            publishLanguages: "default",
+            resolvedPublishLanguages: ["[default]"],
+            dryRun: false,
+            migrateFrom: "space",
+            pipelineResult: {
+                totalItems: 1,
+                finalItems: [],
+                stepReports: [],
+                changedItems: [
+                    {
+                        story: {
+                            id: "story-1",
+                            name: "Home",
+                            full_slug: "home",
+                        },
+                    },
+                ],
+            },
+            writeResults: [
+                {
+                    status: "fulfilled",
+                    value: {
+                        ok: true,
+                        stage: "update",
+                        id: "story-1",
+                        name: "Home",
+                        slug: "home",
+                        sourcePublishState:
+                            "published_with_unpublished_changes",
+                        publishSkippedReason:
+                            "source_story_has_unpublished_changes",
+                    },
+                },
+            ],
+            writeSummary: {
+                total: 1,
+                successful: 1,
+                failed: 0,
+                failedItems: [],
+            },
+        });
+
+        expect(records[0]).toMatchObject({
+            event: "publish_skipped",
+            stage: "update",
+            sourcePublishState: "published_with_unpublished_changes",
+            publishSkippedReason: "source_story_has_unpublished_changes",
+            item: {
+                id: "story-1",
+                slug: "home",
+                spaceId: "target-space",
+            },
+        });
+        expect(records[1]).toMatchObject({
+            event: "migration_write_summary",
+            writeSummary: {
+                successful: 1,
+                failed: 0,
+            },
+        });
+    });
 });

--- a/__tests__/api/stories-update.test.ts
+++ b/__tests__/api/stories-update.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../src/utils/logger.js", () => ({
 import {
     parsePublishLanguagesOption,
     resolvePublishLanguageCodes,
+    resolveStoryPublishState,
     updateStories,
     updateStory,
 } from "../../src/api/stories/stories.js";
@@ -149,6 +150,35 @@ describe("updateStories publish languages", () => {
         expect(() => parsePublishLanguagesOption(",")).toThrow(
             "Publish languages cannot be empty.",
         );
+    });
+
+    it("resolves source story publish states conservatively", () => {
+        expect(resolveStoryPublishState({ published: false })).toMatchObject({
+            status: "draft",
+            shouldPublish: false,
+        });
+        expect(
+            resolveStoryPublishState({
+                published: true,
+                unpublished_changes: true,
+            }),
+        ).toMatchObject({
+            status: "published_with_unpublished_changes",
+            shouldPublish: false,
+        });
+        expect(resolveStoryPublishState({ published: true })).toMatchObject({
+            status: "published_unknown",
+            shouldPublish: false,
+        });
+        expect(
+            resolveStoryPublishState({
+                published: true,
+                unpublished_changes: false,
+            }),
+        ).toMatchObject({
+            status: "published_clean",
+            shouldPublish: true,
+        });
     });
 
     it("resolves all publish languages from the target Storyblok space", async () => {
@@ -413,5 +443,246 @@ describe("updateStories publish languages", () => {
                 response: "invalid story",
             },
         });
+    });
+
+    it("skips language publishing for draft-only source stories when preserving publish state", async () => {
+        const put = vi.fn().mockResolvedValue({
+            data: {
+                story: {
+                    id: "story-1",
+                    name: "Japan",
+                    full_slug: "tours/destinations/japan",
+                },
+            },
+        });
+        const get = vi.fn();
+        const config = {
+            spaceId: "291967263583956",
+            sbApi: {
+                put,
+                get,
+            },
+        } as any;
+        const story = {
+            story: {
+                id: "story-1",
+                name: "Japan",
+                full_slug: "tours/destinations/japan",
+                published: false,
+                unpublished_changes: false,
+            },
+        };
+
+        const results = await updateStories(
+            {
+                stories: [story],
+                spaceId: "291967263583956",
+                options: {
+                    publish: true,
+                    publishLanguages: "default",
+                    preservePublishState: true,
+                },
+            },
+            config,
+        );
+
+        expect(put).toHaveBeenCalledWith(
+            "spaces/291967263583956/stories/story-1",
+            {
+                story: story.story,
+                publish: 0,
+                force_update: 0,
+            },
+        );
+        expect(get).not.toHaveBeenCalled();
+        expect(loggerMock.warning).toHaveBeenCalledWith(
+            "Skipping publish for story 'tours/destinations/japan' in space '291967263583956' because source story was draft-only.",
+        );
+        expect(results[0]).toMatchObject({
+            status: "fulfilled",
+            value: {
+                ok: true,
+                stage: "update",
+                sourcePublishState: "draft",
+                publishSkippedReason: "source_story_draft",
+                publishLanguages: ["[default]"],
+            },
+        });
+    });
+
+    it("skips language publishing for published stories with unpublished draft changes", async () => {
+        const put = vi.fn().mockResolvedValue({
+            data: {
+                story: {
+                    id: "story-1",
+                    name: "Japan",
+                    full_slug: "tours/destinations/japan",
+                },
+            },
+        });
+        const get = vi.fn();
+        const config = {
+            spaceId: "291967263583956",
+            sbApi: {
+                put,
+                get,
+            },
+        } as any;
+        const story = {
+            story: {
+                id: "story-1",
+                name: "Japan",
+                full_slug: "tours/destinations/japan",
+                published: true,
+                unpublished_changes: true,
+            },
+        };
+
+        const results = await updateStories(
+            {
+                stories: [story],
+                spaceId: "291967263583956",
+                options: {
+                    publish: true,
+                    publishLanguages: "default",
+                    preservePublishState: true,
+                },
+            },
+            config,
+        );
+
+        expect(get).not.toHaveBeenCalled();
+        expect(results[0]).toMatchObject({
+            status: "fulfilled",
+            value: {
+                ok: true,
+                stage: "update",
+                sourcePublishState: "published_with_unpublished_changes",
+                publishSkippedReason:
+                    "source_story_has_unpublished_changes",
+            },
+        });
+    });
+
+    it("updates then publishes languages for clean-published source stories", async () => {
+        const put = vi.fn().mockResolvedValue({
+            data: {
+                story: {
+                    id: "story-1",
+                    name: "Japan",
+                    full_slug: "tours/destinations/japan",
+                },
+            },
+        });
+        const get = vi.fn().mockResolvedValue({
+            data: {
+                story: {
+                    id: "story-1",
+                    name: "Japan",
+                    full_slug: "tours/destinations/japan",
+                },
+            },
+        });
+        const config = {
+            spaceId: "291967263583956",
+            sbApi: {
+                put,
+                get,
+            },
+        } as any;
+        const story = {
+            story: {
+                id: "story-1",
+                name: "Japan",
+                full_slug: "tours/destinations/japan",
+                published: true,
+                unpublished_changes: false,
+            },
+        };
+
+        const results = await updateStories(
+            {
+                stories: [story],
+                spaceId: "291967263583956",
+                options: {
+                    publish: true,
+                    publishLanguages: "default",
+                    preservePublishState: true,
+                },
+            },
+            config,
+        );
+
+        expect(put).toHaveBeenCalledWith(
+            "spaces/291967263583956/stories/story-1",
+            {
+                story: story.story,
+                publish: 0,
+                force_update: 0,
+            },
+        );
+        expect(get).toHaveBeenCalledWith(
+            "spaces/291967263583956/stories/story-1/publish",
+            { lang: "[default]" },
+        );
+        expect(put.mock.invocationCallOrder[0]).toBeLessThan(
+            get.mock.invocationCallOrder[0],
+        );
+        expect(results[0]).toMatchObject({
+            status: "fulfilled",
+            value: {
+                ok: true,
+                stage: "publish",
+                publishLanguages: ["[default]"],
+            },
+        });
+    });
+
+    it("preserves source publish state for legacy publish updates when requested", async () => {
+        const put = vi.fn().mockResolvedValue({
+            data: {
+                story: {
+                    id: "story-1",
+                    name: "Japan",
+                    full_slug: "tours/destinations/japan",
+                },
+            },
+        });
+        const config = {
+            spaceId: "291967263583956",
+            sbApi: {
+                put,
+            },
+        } as any;
+        const story = {
+            story: {
+                id: "story-1",
+                name: "Japan",
+                full_slug: "tours/destinations/japan",
+                published: false,
+                unpublished_changes: false,
+            },
+        };
+
+        await updateStories(
+            {
+                stories: [story],
+                spaceId: "291967263583956",
+                options: {
+                    publish: true,
+                    preservePublishState: true,
+                },
+            },
+            config,
+        );
+
+        expect(put).toHaveBeenCalledWith(
+            "spaces/291967263583956/stories/story-1",
+            {
+                story: story.story,
+                publish: 0,
+                force_update: 0,
+            },
+        );
     });
 });

--- a/docs/migrate-content-publish-languages.md
+++ b/docs/migrate-content-publish-languages.md
@@ -65,13 +65,29 @@ Add a language selector flag for content migrations:
 Recommended semantics:
 
 - No `--publish`: update stories as draft only. No publish endpoint calls.
-- `--publish` without `--publishLanguages`: keep the legacy single-update behavior and publish through `PUT /stories/:storyId` with `publish: 1`.
-- `--publish --publishLanguages default`: publish `[default]`.
-- `--publish --publishLanguages all`: fetch configured languages from target space and publish `[default]` plus all configured language codes.
-- `--publish --publishLanguages default,fr,de`: publish `[default],fr,de`.
+- `--publish` without `--publishLanguages`: use the legacy single-update publish mechanism, but only for stories that were clean-published before migration.
+- `--publish --publishLanguages default`: publish `[default]`, but only for stories that were clean-published before migration.
+- `--publish --publishLanguages all`: fetch configured languages from target space and publish `[default]` plus all configured language codes, but only for stories that were clean-published before migration.
+- `--publish --publishLanguages default,fr,de`: publish `[default],fr,de`, but only for stories that were clean-published before migration.
 - `default` should normalize to Storyblok's `[default]` token.
 - `[default]` should also be accepted directly for advanced users.
 - Configured space languages must come from Storyblok, not from app locale config.
+
+## Preserve Source Publish State
+
+The migration must not publish editor draft work by accident. Before updating each story, use the Storyblok source story metadata to decide whether publishing is allowed.
+
+Safe story-level map:
+
+| Source story state | Migration behavior |
+| --- | --- |
+| `published: false` | Save migrated story as draft. Skip publish. |
+| `published: true` and `unpublished_changes: true` | Save migrated story as draft. Skip publish. |
+| `published: true` and `unpublished_changes: false` | Save migrated story first. Then publish requested languages. |
+
+If `published` is true but `unpublished_changes` is missing, skip publish. This is conservative and avoids publishing unknown draft state from older saved files.
+
+When publish is skipped, the migration should log the skip reason and include it in the JSONL run log.
 
 ## Required Ordering
 
@@ -89,6 +105,10 @@ if (!updateResult.ok) {
 }
 
 if (options.publish) {
+    if (!sourceStoryWasCleanPublished(story)) {
+        return updateResult;
+    }
+
     return publishStoryLanguages(story.id, publishLanguages, config);
 }
 
@@ -155,10 +175,11 @@ spaces/:spaceId/stories/:storyId/publish?lang=${encodeURIComponent(lang)}
 
 6. Change write flow.
    - When `--publish` is false, keep current draft update behavior.
-   - When `--publish` is true and `--publishLanguages` is not provided, preserve the legacy single `PUT` with `publish: 1`.
+   - When `--publish` is true and `--publishLanguages` is not provided, use the legacy single `PUT` with `publish: 1` only for stories that were clean-published before migration.
    - When `--publish` is true and `--publishLanguages` is provided:
      - Update story with `publish: false`.
-     - If update succeeds, publish requested languages.
+     - If update succeeds and the source story was clean-published, publish requested languages.
+     - If update succeeds but the source story was draft-only or had unpublished changes, skip publish and log why.
      - If update fails, do not publish that story.
    - This can live inside `updateStories` so call sites keep one write operation per changed story.
 
@@ -191,7 +212,7 @@ sb-mig migrate content --all --from 123 --to 123 --migration v3toV4 --publish --
 ## Open Decisions
 
 - Default for `--publish` without `--publishLanguages`:
-  - Decision: preserve legacy `PUT` publish behavior for backwards compatibility.
+  - Decision: use legacy `PUT` publish behavior, but gate it with source publish-state preservation inside `migrate content`.
   - Use `--publish --publishLanguages default` when the explicit update-then-publish endpoint flow is desired for the default language.
 
 - Failure model:
@@ -205,8 +226,10 @@ sb-mig migrate content --all --from 123 --to 123 --migration v3toV4 --publish --
 ## Acceptance Criteria
 
 - Draft-only migrations continue to work unchanged.
-- Existing `--publish` behavior remains compatible unless `--publishLanguages` is provided.
-- `--publish --publishLanguages all` updates each changed story first, then publishes `[default]` plus configured target-space languages.
+- `migrate content --publish` does not publish stories that were draft-only before migration.
+- `migrate content --publish` does not publish stories that had unpublished changes before migration.
+- `--publish --publishLanguages all` updates each changed clean-published story first, then publishes `[default]` plus configured target-space languages.
 - A failed update never triggers publish for that story.
+- A skipped publish is visible in CLI output and migration run logs.
 - A failed publish is visible in CLI output and migration run logs.
 - Tests cover ordering, language normalization, automatic language fetch, and failure handling.

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -1007,6 +1007,7 @@ export const doTheMigration = async (
                 options: {
                     publish: Boolean(publish),
                     publishLanguages: resolvedPublishLanguages,
+                    preservePublishState: Boolean(publish),
                 },
             },
             config,

--- a/src/api/data-migration/migration-run-log.ts
+++ b/src/api/data-migration/migration-run-log.ts
@@ -18,6 +18,7 @@ type MigrationRunLogEvent =
     | "update_failed"
     | "publish_success"
     | "publish_failed"
+    | "publish_skipped"
     | "migration_write_summary";
 
 export interface MigrationRunLogRecord {
@@ -54,6 +55,8 @@ export interface MigrationRunLogRecord {
             status?: number | string;
             response?: string | null;
             stage?: "update" | "publish";
+            sourcePublishState?: string;
+            publishSkippedReason?: string;
         }>;
     };
     item?: {
@@ -66,6 +69,8 @@ export interface MigrationRunLogRecord {
     status?: number | string | null;
     response?: string | null;
     stage?: "update" | "publish";
+    sourcePublishState?: string;
+    publishSkippedReason?: string;
     error?: unknown;
 }
 
@@ -177,13 +182,15 @@ export const buildMigrationRunLogRecords = ({
                 pipelineResult.changedItems[index],
             );
             const stage = value.stage || "update";
-            const event: MigrationRunLogEvent = value.ok
-                ? stage === "publish"
-                    ? "publish_success"
-                    : "update_success"
-                : stage === "publish"
-                  ? "publish_failed"
-                  : "update_failed";
+            const event: MigrationRunLogEvent = value.publishSkippedReason
+                ? "publish_skipped"
+                : value.ok
+                  ? stage === "publish"
+                      ? "publish_success"
+                      : "update_success"
+                  : stage === "publish"
+                    ? "publish_failed"
+                    : "update_failed";
 
             return {
                 ...baseRecord,
@@ -201,6 +208,8 @@ export const buildMigrationRunLogRecords = ({
                 status: value.status || null,
                 response: value.response || null,
                 stage,
+                sourcePublishState: value.sourcePublishState,
+                publishSkippedReason: value.publishSkippedReason,
                 ...(value.ok ? {} : { error: serializeError(value.error) }),
             };
         },
@@ -221,6 +230,8 @@ export const buildMigrationRunLogRecords = ({
                 status: item.status,
                 response: item.response || null,
                 stage: item.stage,
+                sourcePublishState: item.sourcePublishState,
+                publishSkippedReason: item.publishSkippedReason,
             })),
         },
     };

--- a/src/api/data-migration/write-summary.ts
+++ b/src/api/data-migration/write-summary.ts
@@ -8,6 +8,8 @@ export interface MutationWriteResult {
     status?: number | string;
     response?: string | null;
     publishLanguages?: string[];
+    sourcePublishState?: string;
+    publishSkippedReason?: string;
     error?: unknown;
 }
 

--- a/src/api/stories/stories.ts
+++ b/src/api/stories/stories.ts
@@ -28,6 +28,40 @@ const resolveStoryLabel = (
 
 const DEFAULT_PUBLISH_LANGUAGE = "[default]";
 
+type StoryPublishState =
+    | {
+          status: "draft";
+          shouldPublish: false;
+          skipReason: "source_story_draft";
+          message: string;
+      }
+    | {
+          status: "published_with_unpublished_changes";
+          shouldPublish: false;
+          skipReason: "source_story_has_unpublished_changes";
+          message: string;
+      }
+    | {
+          status: "published_unknown";
+          shouldPublish: false;
+          skipReason: "source_story_publish_state_unknown";
+          message: string;
+      }
+    | {
+          status: "published_clean";
+          shouldPublish: true;
+      };
+
+type SkippedStoryPublishState = Extract<
+    StoryPublishState,
+    { shouldPublish: false }
+>;
+
+const isSkippedStoryPublishState = (
+    publishState: StoryPublishState | undefined,
+): publishState is SkippedStoryPublishState =>
+    publishState?.shouldPublish === false;
+
 const isDefaultLanguageToken = (language: string): boolean =>
     language.toLowerCase() === "default" ||
     language === DEFAULT_PUBLISH_LANGUAGE;
@@ -46,6 +80,70 @@ const normalizePublishLanguageCodes = (languages: string[]): string[] => {
     }
 
     return Array.from(new Set(cleanLanguages));
+};
+
+export const resolveStoryPublishState = (story: any): StoryPublishState => {
+    if (story?.published !== true) {
+        return {
+            status: "draft",
+            shouldPublish: false,
+            skipReason: "source_story_draft",
+            message: "source story was draft-only",
+        };
+    }
+
+    if (story.unpublished_changes === true) {
+        return {
+            status: "published_with_unpublished_changes",
+            shouldPublish: false,
+            skipReason: "source_story_has_unpublished_changes",
+            message: "source story had unpublished draft changes",
+        };
+    }
+
+    if (story.unpublished_changes !== false) {
+        return {
+            status: "published_unknown",
+            shouldPublish: false,
+            skipReason: "source_story_publish_state_unknown",
+            message:
+                "source story publish state was missing unpublished_changes",
+        };
+    }
+
+    return {
+        status: "published_clean",
+        shouldPublish: true,
+    };
+};
+
+const withSkippedPublish = ({
+    updateResult,
+    story,
+    storyId,
+    spaceId,
+    publishLanguages,
+    publishState,
+}: {
+    updateResult: any;
+    story: Record<string, any>;
+    storyId: string | number;
+    spaceId: string;
+    publishLanguages?: string[];
+    publishState: SkippedStoryPublishState;
+}) => {
+    const storyLabel = resolveStoryLabel(story, String(storyId));
+
+    Logger.warning(
+        `Skipping publish for story '${storyLabel}' in space '${spaceId}' because ${publishState.message}.`,
+    );
+
+    return {
+        ...updateResult,
+        sourcePublishState: publishState.status,
+        publishSkippedReason: publishState.skipReason,
+        ...(publishLanguages ? { publishLanguages } : {}),
+    };
 };
 
 export const parsePublishLanguagesOption = (
@@ -438,6 +536,7 @@ export const updateStories: UpdateStories = async (args, config) => {
     const { stories, options, spaceId } = args;
     const shouldPublishLanguages =
         options.publish && options.publishLanguages !== undefined;
+    const shouldPreservePublishState = Boolean(options.preservePublishState);
     const publishLanguages = shouldPublishLanguages
         ? await resolvePublishLanguageCodes(options.publishLanguages, {
               ...config,
@@ -449,14 +548,36 @@ export const updateStories: UpdateStories = async (args, config) => {
         // Run through stories, and update the space with migrated version of stories
         stories.map(async (stories: any) => {
             const story = stories.story;
+            const publishState = shouldPreservePublishState
+                ? resolveStoryPublishState(story)
+                : undefined;
+            const shouldPublishStory =
+                options.publish &&
+                (!publishState || publishState.shouldPublish);
             const updateResult = await updateStory(
                 story,
                 story.id,
                 {
-                    publish: options.publish && !shouldPublishLanguages,
+                    publish: shouldPublishStory && !shouldPublishLanguages,
+                    force_update: options.force_update,
                 },
                 { ...config, spaceId },
             );
+
+            if (
+                options.publish &&
+                updateResult?.ok &&
+                isSkippedStoryPublishState(publishState)
+            ) {
+                return withSkippedPublish({
+                    updateResult,
+                    story,
+                    storyId: story.id,
+                    spaceId,
+                    publishLanguages,
+                    publishState,
+                });
+            }
 
             if (
                 !shouldPublishLanguages ||

--- a/src/api/stories/stories.types.ts
+++ b/src/api/stories/stories.types.ts
@@ -9,6 +9,7 @@ interface ModifyStoryOptions {
     publish?: boolean;
     force_update?: boolean;
     publishLanguages?: PublishLanguagesOption;
+    preservePublishState?: boolean;
 }
 
 export type PublishLanguagesOption = "default" | "all" | string[];

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -101,8 +101,8 @@ export const migrateDescription = `
         --startsWith      - Filter stories by starts_with prefix
         --yes             - Skip ask for confirmation (dangerous, but useful in CI/CD)
         --dry-run         - Preview what would be migrated without making any API changes
-        --publish         - Publish changed stories immediately after migration. Default: save draft. [content only]
-        --publishLanguages - Languages to publish when --publish is set. Values: default, all, or comma-separated Storyblok language codes. [content only]
+        --publish         - Publish changed stories after migration only if they were clean-published before migration. Default: save draft. [content only]
+        --publishLanguages - Languages to publish when --publish is set. Values: default, all, or comma-separated Storyblok language codes. Skips stories that were draft-only or had unpublished changes before migration. [content only]
         --fileName        - Stable base name for migration output files (disables timestamp suffix for migration artifacts)
 
     EXAMPLES


### PR DESCRIPTION
## Summary
- preserve source Storyblok publish state for `migrate content --publish`
- skip publishing stories that were draft-only, had unpublished changes, or have unknown `unpublished_changes` state
- log skipped publishes in CLI output and JSONL migration run logs
- update docs/help text and add focused coverage for draft, stale-published, and clean-published stories

## Jira
- GCTT-3715: https://centralcreativestudio.atlassian.net/browse/GCTT-3715

## Validation
- `npm run test -- __tests__/api/stories-update.test.ts __tests__/api/migration-run-log.test.ts`
- `npm run typecheck`
- `npx tsc-files --noEmit -p __tests__/tsconfig.json __tests__/api/stories-update.test.ts __tests__/api/migration-run-log.test.ts`
- `npm run lint`
- `npm run test:unit`
- `npm run build`