### PR TITLE
fix(windows): harden path handling and CI

### DIFF
--- a/.github/workflows/build_and_test_on_windows.yml
+++ b/.github/workflows/build_and_test_on_windows.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - beta
+  workflow_dispatch:
 
 jobs:
   build:
@@ -30,6 +31,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type Check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
       - name: Build
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -37,6 +44,14 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm run build
+
+      - name: Windows portability regression tests
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm run test:unit -- __tests__/utils/files.test.ts __tests__/config/config-loader.test.ts __tests__/utils/path-utils.test.ts __tests__/utils/glob-utils.test.ts __tests__/build-on-the-fly.test.ts __tests__/utils/async-utils.test.ts __tests__/api/migration-run-log.test.ts __tests__/api/write-summary.test.ts
 
       - name: Test
         env:

--- a/__tests__/utils/async-utils.test.ts
+++ b/__tests__/utils/async-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { delay } from "../../src/utils/async-utils.js";
+import { delay, mapWithConcurrency } from "../../src/utils/async-utils.js";
 
 describe("delay - async delay utility", () => {
     it("should delay execution for specified time", async () => {
@@ -45,5 +45,31 @@ describe("delay - async delay utility", () => {
         await delayPromise;
 
         vi.useRealTimers();
+    });
+});
+
+describe("mapWithConcurrency", () => {
+    it("preserves result order while limiting concurrent work", async () => {
+        let active = 0;
+        let maxActive = 0;
+
+        const result = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (
+            item,
+        ) => {
+            active++;
+            maxActive = Math.max(maxActive, active);
+            await new Promise((resolve) => setTimeout(resolve, 1));
+            active--;
+            return item * 2;
+        });
+
+        expect(result).toEqual([2, 4, 6, 8, 10]);
+        expect(maxActive).toBeLessThanOrEqual(2);
+    });
+
+    it("handles empty input", async () => {
+        await expect(
+            mapWithConcurrency([], 2, async (item) => item),
+        ).resolves.toEqual([]);
     });
 });

--- a/__tests__/utils/files.test.ts
+++ b/__tests__/utils/files.test.ts
@@ -6,7 +6,6 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
     createDir,
-    getFileContent,
     readFile,
     toImportSpecifier,
 } from "../../src/utils/files.js";
@@ -24,19 +23,6 @@ describe("files utilities", () => {
         for (const dir of tempDirs.splice(0)) {
             fs.rmSync(dir, { recursive: true, force: true });
         }
-    });
-
-    it("loads an absolute module path via a file URL compatible import", async () => {
-        const tempDir = makeTempDir();
-        const modulePath = path.join(tempDir, "config.mjs");
-        fs.writeFileSync(
-            modulePath,
-            "export default { componentsDirectories: ['src'] };\n",
-        );
-
-        await expect(getFileContent({ file: modulePath })).resolves.toEqual({
-            componentsDirectories: ["src"],
-        });
     });
 
     it("converts Windows absolute paths to importable file URLs", () => {

--- a/__tests__/utils/files.test.ts
+++ b/__tests__/utils/files.test.ts
@@ -1,0 +1,53 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createDir, getFileContent, readFile } from "../../src/utils/files.js";
+
+describe("files utilities", () => {
+    const tempDirs: string[] = [];
+
+    const makeTempDir = () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sb-mig-files-"));
+        tempDirs.push(dir);
+        return dir;
+    };
+
+    afterEach(() => {
+        for (const dir of tempDirs.splice(0)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("loads an absolute module path via a file URL compatible import", async () => {
+        const tempDir = makeTempDir();
+        const modulePath = path.join(tempDir, "config with spaces.mjs");
+        fs.writeFileSync(
+            modulePath,
+            "export default { componentsDirectories: ['src'] };\n",
+        );
+
+        await expect(getFileContent({ file: modulePath })).resolves.toEqual({
+            componentsDirectories: ["src"],
+        });
+    });
+
+    it("creates absolute directories without prefixing process.cwd()", async () => {
+        const tempDir = makeTempDir();
+        const targetDir = path.join(tempDir, "absolute", "nested");
+
+        await createDir(targetDir);
+
+        expect(fs.existsSync(targetDir)).toBe(true);
+    });
+
+    it("reads absolute paths without prefixing process.cwd()", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "data.json");
+        fs.writeFileSync(filePath, '{"ok":true}\n');
+
+        await expect(readFile(filePath)).resolves.toBe('{"ok":true}\n');
+    });
+});

--- a/__tests__/utils/files.test.ts
+++ b/__tests__/utils/files.test.ts
@@ -4,7 +4,12 @@ import path from "path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createDir, getFileContent, readFile } from "../../src/utils/files.js";
+import {
+    createDir,
+    getFileContent,
+    readFile,
+    toImportSpecifier,
+} from "../../src/utils/files.js";
 
 describe("files utilities", () => {
     const tempDirs: string[] = [];
@@ -23,7 +28,7 @@ describe("files utilities", () => {
 
     it("loads an absolute module path via a file URL compatible import", async () => {
         const tempDir = makeTempDir();
-        const modulePath = path.join(tempDir, "config with spaces.mjs");
+        const modulePath = path.join(tempDir, "config.mjs");
         fs.writeFileSync(
             modulePath,
             "export default { componentsDirectories: ['src'] };\n",
@@ -32,6 +37,17 @@ describe("files utilities", () => {
         await expect(getFileContent({ file: modulePath })).resolves.toEqual({
             componentsDirectories: ["src"],
         });
+    });
+
+    it("converts Windows absolute paths to importable file URLs", () => {
+        const specifier = toImportSpecifier(
+            "C:\\Users\\Runner Admin\\project\\config with spaces.mjs",
+            "win32",
+        );
+
+        expect(specifier).toBe(
+            "file:///C:/Users/Runner%20Admin/project/config%20with%20spaces.mjs",
+        );
     });
 
     it("creates absolute directories without prefixing process.cwd()", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sb-mig",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sb-mig",
-      "version": "6.0.0-beta.3",
+      "version": "6.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-swc": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "lint-staged": "node ./src/scripts/fix-esm.js && lint-staged",
-    "build": "rm -rf dist dist-cjs && tsc -p tsconfig.json && tsc -p tsconfig.api-v2.cjs.json && node ./src/scripts/write-cjs-package.js && chmod +x ./dist/cli/index.js",
+    "build": "node ./src/scripts/clean-build.js && tsc -p tsconfig.json && tsc -p tsconfig.api-v2.cjs.json && node ./src/scripts/write-cjs-package.js && node ./src/scripts/make-cli-executable.js",
     "build:dev": "chokidar 'src/**/*.{js,ts,cjs,mjs}' -c 'npm run build'",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint --fix",

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -509,7 +509,6 @@ export const runMigrationPipelineInMemory = ({
     itemsToMigrate: any[];
     preparedMigrationConfigs: PreparedMigrationConfig[];
 }): MigrationPipelineResult => {
-    const originalItems = deepClone(itemsToMigrate);
     let workingItems = deepClone(itemsToMigrate);
 
     const stepReports: MigrationStepReport[] = [];
@@ -561,7 +560,7 @@ export const runMigrationPipelineInMemory = ({
     }
 
     const changedItems = workingItems.filter((item, index) => {
-        const originalItem = originalItems[index];
+        const originalItem = itemsToMigrate[index];
 
         if (!originalItem) {
             return true;

--- a/src/api/stories/stories.ts
+++ b/src/api/stories/stories.ts
@@ -16,6 +16,7 @@ import type {
 
 import chalk from "chalk";
 
+import { mapWithConcurrency } from "../../utils/async-utils.js";
 import Logger from "../../utils/logger.js";
 import { notNullish } from "../../utils/object-utils.js";
 import { getAllItemsWithPagination } from "../utils/request.js";
@@ -27,6 +28,7 @@ const resolveStoryLabel = (
     content?.full_slug || content?.slug || content?.name || String(storyId);
 
 const DEFAULT_PUBLISH_LANGUAGE = "[default]";
+const STORY_CONTENT_FETCH_CONCURRENCY = 10;
 
 const isDefaultLanguageToken = (language: string): boolean =>
     language.toLowerCase() === "default" ||
@@ -231,8 +233,10 @@ export const getAllStories: GetAllStories = async (args, config) => {
 
     let heartBeat = 0;
 
-    const allStories = await Promise.all(
-        allStoriesWithoutContent.map(async (story: any) => {
+    const allStories = await mapWithConcurrency(
+        allStoriesWithoutContent,
+        STORY_CONTENT_FETCH_CONCURRENCY,
+        async (story: any) => {
             const result = await getStoryById(story.id, config);
 
             heartBeat++;
@@ -246,7 +250,7 @@ export const getAllStories: GetAllStories = async (args, config) => {
             }
 
             return result;
-        }),
+        },
     );
 
     return allStories;

--- a/src/config/helper.ts
+++ b/src/config/helper.ts
@@ -1,4 +1,9 @@
+import { pathToFileURL } from "url";
+
 import Logger from "../utils/logger.js";
+
+const toImportSpecifier = (filePath: string): string =>
+    process.platform === "win32" ? pathToFileURL(filePath).href : filePath;
 
 export { defaultConfig } from "./defaultConfig.js";
 export { SCHEMA } from "./constants.js";
@@ -7,12 +12,10 @@ export const getStoryblokConfigContent = (data: {
     filePath: string;
     ext: string;
 }): any => {
-    let prefix = "";
+    const configSpecifier = toImportSpecifier(`${data.filePath}${data.ext}`);
+    const fallbackConfigSpecifier = toImportSpecifier(`${data.filePath}.mjs`);
 
-    if (process.platform === "win32") {
-        prefix = "file://";
-    }
-    return import(`${prefix}${data.filePath}${data.ext}`)
+    return import(/* @vite-ignore */ configSpecifier)
         .then((res) => {
             Logger.success("Found storyblok.config.js!");
             return res.default;
@@ -21,10 +24,9 @@ export const getStoryblokConfigContent = (data: {
             Logger.warning("Cannot find requested file with .js extension.");
             Logger.log("Trying .mjs extension\n");
 
-            return import(`${prefix}${data.filePath}.mjs`)
+            return import(/* @vite-ignore */ fallbackConfigSpecifier)
                 .then((res) => {
                     Logger.success("Found storyblok.config.mjs!");
-                    console.log("res", res);
                     return res.default;
                 })
                 .catch(() => {

--- a/src/scripts/clean-build.js
+++ b/src/scripts/clean-build.js
@@ -1,0 +1,5 @@
+import fs from "fs";
+
+for (const dir of ["dist", "dist-cjs"]) {
+    fs.rmSync(dir, { recursive: true, force: true });
+}

--- a/src/scripts/make-cli-executable.js
+++ b/src/scripts/make-cli-executable.js
@@ -1,0 +1,5 @@
+import fs from "fs";
+
+if (process.platform !== "win32") {
+    fs.chmodSync("./dist/cli/index.js", 0o755);
+}

--- a/src/utils/async-utils.ts
+++ b/src/utils/async-utils.ts
@@ -13,3 +13,34 @@
  */
 export const delay = (time: number): Promise<void> =>
     new Promise((resolve) => setTimeout(resolve, time));
+
+export const mapWithConcurrency = async <T, R>(
+    items: T[],
+    concurrency: number,
+    mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> => {
+    if (items.length === 0) {
+        return [];
+    }
+
+    const limit = Math.max(1, Math.floor(concurrency));
+    const results = new Array<R>(items.length);
+    let nextIndex = 0;
+
+    const workers = Array.from(
+        { length: Math.min(limit, items.length) },
+        async () => {
+            while (nextIndex < items.length) {
+                const currentIndex = nextIndex++;
+                results[currentIndex] = await mapper(
+                    items[currentIndex] as T,
+                    currentIndex,
+                );
+            }
+        },
+    );
+
+    await Promise.all(workers);
+
+    return results;
+};

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -3,7 +3,8 @@ import type { RequestBaseConfig } from "../api/utils/request.js";
 import * as fs from "fs";
 import { writeFile } from "fs";
 import { createRequire } from "module";
-import path from "path";
+import nodePath from "path";
+import { pathToFileURL } from "url";
 
 import pkg from "ncp";
 
@@ -11,6 +12,23 @@ import { generateDatestamp } from "./date-utils.js";
 import Logger from "./logger.js";
 
 const { ncp } = pkg;
+
+const resolveFromCwd = (filePath: string): string =>
+    nodePath.isAbsolute(filePath)
+        ? filePath
+        : nodePath.resolve(process.cwd(), filePath);
+
+const toImportSpecifier = (filePath: string): string => {
+    if (/^(file|data|node):/.test(filePath)) {
+        return filePath;
+    }
+
+    const resolvedPath = resolveFromCwd(filePath);
+
+    return process.platform === "win32"
+        ? pathToFileURL(resolvedPath).href
+        : resolvedPath;
+};
 
 // ============================================================================
 // File Content Loading
@@ -24,7 +42,7 @@ const { ncp } = pkg;
  * @returns The default export of the imported module
  */
 export const getFileContent = (data: { file: string }): any => {
-    return import(data.file)
+    return import(/* @vite-ignore */ toImportSpecifier(data.file))
         .then((res) => {
             return res.default;
         })
@@ -68,7 +86,7 @@ export const getFilesContentWithRequire = (data: { files: string[] }) => {
  * @returns Parsed package.json object
  */
 export const getPackageJson = () => {
-    const packageJsonPath = path.join(process.cwd(), "package.json");
+    const packageJsonPath = nodePath.join(process.cwd(), "package.json");
     const packageJsonContent = fs.readFileSync(packageJsonPath, "utf-8");
     const packageJson = JSON.parse(packageJsonContent);
     return packageJson;
@@ -77,7 +95,7 @@ export const getPackageJson = () => {
 export const isDirectoryExists = (path: string) => fs.existsSync(path);
 
 export const createDir = async (dirPath: string) => {
-    await fs.promises.mkdir(`${process.cwd()}/${dirPath}`, {
+    await fs.promises.mkdir(resolveFromCwd(dirPath), {
         recursive: true,
     });
 };
@@ -129,11 +147,11 @@ export const copyFolder = async (src: string, dest: string) => {
 };
 
 export const copyFile = async (src: string, dest: string) => {
-    const directory = dest.split("/").slice(0, dest.split("/").length - 1);
-    const fileName = src.split("/")[src.split("/").length - 1];
+    const directory = nodePath.dirname(dest);
+    const fileName = nodePath.basename(src);
 
-    if (!isDirectoryExists(directory.join("/"))) {
-        await createDir(directory.join("/"));
+    if (!isDirectoryExists(directory)) {
+        await createDir(directory);
     }
 
     fs.copyFile(src, dest, (err) => {
@@ -222,10 +240,7 @@ export const createAndSaveToFile: CreateAndSaveToFile = async (
     }
 
     if (path) {
-        const folderPath = path
-            .split("/")
-            .slice(0, path.split("/").length - 1)
-            .join("/");
+        const folderPath = nodePath.dirname(path);
         await createDir(folderPath);
         await createJsonFile(JSON.stringify(res, undefined, 2), path);
 
@@ -261,7 +276,7 @@ export const createAndSaveComponentListToFile: CreateAndSaveComponentListToFile 
     };
 
 export const readFile = async (pathToFile: string) => {
-    const absolutePath = path.join(process.cwd(), pathToFile);
+    const absolutePath = resolveFromCwd(pathToFile);
 
     try {
         const result = await fs.promises.readFile(absolutePath);
@@ -285,14 +300,14 @@ export const dumpToFile = async (path: string, content: string) => {
 
 export const getConsumerPackageJson = async () => {
     const consumerPkg = await getFileContentWithRequire({
-        file: path.join(process.cwd(), "package.json"),
+        file: nodePath.join(process.cwd(), "package.json"),
     });
     return consumerPkg;
 };
 
 export const getSbMigPackageJson = async () => {
     const sbMigPkg = await getFileContentWithRequire({
-        file: path.join("..", "..", "package.json"),
+        file: nodePath.join("..", "..", "package.json"),
     });
     return sbMigPkg;
 };

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -13,20 +13,27 @@ import Logger from "./logger.js";
 
 const { ncp } = pkg;
 
-const resolveFromCwd = (filePath: string): string =>
-    nodePath.isAbsolute(filePath)
+const resolveFromCwd = (
+    filePath: string,
+    pathApi: typeof nodePath = nodePath,
+): string =>
+    pathApi.isAbsolute(filePath)
         ? filePath
-        : nodePath.resolve(process.cwd(), filePath);
+        : pathApi.resolve(process.cwd(), filePath);
 
-const toImportSpecifier = (filePath: string): string => {
+export const toImportSpecifier = (
+    filePath: string,
+    platform: NodeJS.Platform = process.platform,
+): string => {
     if (/^(file|data|node):/.test(filePath)) {
         return filePath;
     }
 
-    const resolvedPath = resolveFromCwd(filePath);
+    const pathApi = platform === "win32" ? nodePath.win32 : nodePath;
+    const resolvedPath = resolveFromCwd(filePath, pathApi);
 
-    return process.platform === "win32"
-        ? pathToFileURL(resolvedPath).href
+    return platform === "win32"
+        ? pathToFileURL(resolvedPath, { windows: true }).href
         : resolvedPath;
 };
 


### PR DESCRIPTION
## Summary
- replace Unix-only build shell commands with Node scripts for Windows compatibility
- make config/module loading and file helpers safer for Windows absolute paths
- reduce migration memory pressure with bounded story fetch concurrency and less cloning
- add focused Windows portability regression coverage and run it in Windows CI

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run build`

## Manual Windows QA
Please run these steps on a real Windows machine after pulling this PR or branch `windows-improvements`.

### Environment
- Windows 10/11
- PowerShell
- Node.js `22.x` or `24.x`
- Fresh checkout of `sb-mig`

### 1. Repo install, build, and focused regression checks
```powershell
git checkout windows-improvements
npm ci
npm run typecheck
npm run lint
npm run build
npm run test:unit -- __tests__/utils/files.test.ts __tests__/config/config-loader.test.ts __tests__/utils/path-utils.test.ts __tests__/utils/glob-utils.test.ts __tests__/build-on-the-fly.test.ts __tests__/utils/async-utils.test.ts __tests__/api/migration-run-log.test.ts __tests__/api/write-summary.test.ts
```

Expected:
- `npm run build` works on Windows without `rm -rf` or `chmod` failures.
- Focused tests pass on Node 22 and Node 24 if possible.

### 2. Packaged CLI smoke test
```powershell
npm pack
node scripts/package-smoke.mjs
```

Expected:
- The packed package installs into a temporary project.
- `sb-mig --help` works.
- `sb-mig discover components --all` finds the sample `hero` component.
- `sb-mig/api-v2` works from both CJS and ESM consumers.

### 3. Manual CLI path smoke test in a folder with spaces
Create a folder with spaces in the path:
```powershell
mkdir "C:\Temp\sb mig windows smoke"
cd "C:\Temp\sb mig windows smoke"
npm init -y
```

Create `storyblok.config.mjs`:
```js
export default {
  componentsDirectories: ["src/components"],
  schemaFileExt: "sb.js",
  sbmigWorkingDirectory: "sbmig",
};
```

Create `src/components/hero.sb.js`:
```js
export default {
  name: "hero",
  display_name: "Hero",
  is_root: false,
  is_nestable: true,
  schema: {
    title: { type: "text" },
  },
};
```

From that smoke project, run the locally built CLI from the repo checkout:
```powershell
node "<path-to-sb-mig-repo>\dist\cli\index.js" --help
node "<path-to-sb-mig-repo>\dist\cli\index.js" discover components --all
```

Expected:
- Config loading works from a Windows path with spaces.
- Discovery output includes `hero`.
- No `ERR_UNSUPPORTED_ESM_URL_SCHEME`, `Cannot find requested file`, or path separator errors.

### 4. Content migration memory sanity check
For a real consuming project/space, run the smallest safe dry run first:
```powershell
sb-mig migrate content --all --migrateFrom space --from <space-id> --to <space-id> --migration <migration-name> --dryRun --withSlug <known-story-full-slug>
```

Then, if that passes, try a broader dry run:
```powershell
sb-mig migrate content --all --migrateFrom space --from <space-id> --to <space-id> --migration <migration-name> --dryRun --startsWith <folder-prefix>
```

Expected:
- Dry-run artifacts are written under `sbmig/migrations`.
- Memory stays stable enough to complete on a weaker Windows laptop.
- Logs show bounded story fetching progress instead of a large all-at-once fetch spike.

### Report back with
- Windows version
- Node version (`node -v`)
- Command that failed, if any
- Full terminal output around the error
- Whether the project path contained spaces or special characters

## Notes
- `GCTT-3692` has no concrete failing command/log, so this PR targets the Windows failure classes found in code inspection: dynamic imports, path resolution, glob-facing path behavior, shell scripts, and migration memory pressure.