### PR TITLE
fix: resolve schema imports during precompile

### DIFF
--- a/__tests__/build-on-the-fly.test.ts
+++ b/__tests__/build-on-the-fly.test.ts
@@ -1,5 +1,11 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { createRequire } from "module";
+import { tmpdir } from "os";
+import path from "path";
+
 import { describe, it, expect } from "vitest";
 
+import { buildOnTheFly } from "../src/rollup/build-on-the-fly.js";
 import { extractComponentName as _extractComponentName } from "../src/utils/path-utils.js";
 
 describe("Build Typescript on-the-fly", () => {
@@ -54,5 +60,110 @@ describe("Build Typescript on-the-fly", () => {
         it("handles bare file names (no separator)", () => {
             expect(_extractComponentName("hero.sb.ts")).toBe("hero.sb");
         });
+    });
+
+    it("resolves extensionless TypeScript schema imports and tsconfig path aliases", async () => {
+        const tempDirectory = await mkdtemp(
+            path.join(tmpdir(), "sb-mig-build-"),
+        );
+
+        try {
+            await mkdir(path.join(tempDirectory, "src", "plugin-schemas"), {
+                recursive: true,
+            });
+
+            await writeFile(
+                path.join(tempDirectory, "tsconfig.json"),
+                JSON.stringify({
+                    compilerOptions: {
+                        baseUrl: ".",
+                        paths: {
+                            "@/*": ["src/*"],
+                        },
+                    },
+                }),
+            );
+
+            await writeFile(
+                path.join(
+                    tempDirectory,
+                    "src",
+                    "plugin-schemas",
+                    "breakpoints.schema.ts",
+                ),
+                `
+                    export const breakpointsSchema = {
+                        spacing: { type: "custom", field_type: "spacing" },
+                    };
+                `,
+            );
+
+            await writeFile(
+                path.join(tempDirectory, "src", "shared.schema.ts"),
+                `
+                    export const sharedSchema = {
+                        color: { type: "custom", field_type: "color" },
+                    };
+                `,
+            );
+
+            const schemaFile = path.join(
+                tempDirectory,
+                "src",
+                "example.sb.ts",
+            );
+
+            await writeFile(
+                schemaFile,
+                `
+                    import { breakpointsSchema } from "./plugin-schemas/breakpoints.schema";
+                    import { sharedSchema } from "@/shared.schema";
+
+                    export default {
+                        name: "example",
+                        schema: {
+                            design: {
+                                type: "custom",
+                                options: [
+                                    {
+                                        name: "spacing",
+                                        value: JSON.stringify(breakpointsSchema.spacing),
+                                    },
+                                    {
+                                        name: "color",
+                                        value: JSON.stringify(sharedSchema.color),
+                                    },
+                                ],
+                            },
+                        },
+                    };
+                `,
+            );
+
+            await buildOnTheFly({
+                files: [schemaFile],
+                projectDir: tempDirectory,
+            });
+
+            const compiledFile = path.join(
+                tempDirectory,
+                ".next",
+                "cache",
+                "sb-mig",
+                "example.sb.cjs",
+            );
+            const compiledContent = await readFile(compiledFile, "utf8");
+            const require = createRequire(import.meta.url);
+            const requiredSchema = require(compiledFile);
+            const compiledSchema = requiredSchema.default ?? requiredSchema;
+
+            expect(compiledContent).not.toContain(
+                "./plugin-schemas/breakpoints.schema",
+            );
+            expect(compiledContent).not.toContain("@/shared.schema");
+            expect(compiledSchema.schema.design.options).toHaveLength(2);
+        } finally {
+            await rm(tempDirectory, { recursive: true, force: true });
+        }
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "sb-mig",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sb-mig",
-      "version": "6.0.0-beta.3",
+      "version": "6.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
+        "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-swc": "^0.4.0",
         "@swc/core": "1.3.41",
         "@swc/helpers": "^0.5.18",
@@ -33,7 +34,6 @@
       "devDependencies": {
         "@commitlint/cli": "^17.7.1",
         "@commitlint/config-conventional": "^17.7.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
         "@ryansonshine/commitizen": "^4.2.8",
         "@ryansonshine/cz-conventional-changelog": "^3.3.4",
         "@semantic-release/changelog": "^6.0.3",
@@ -1418,7 +1418,6 @@
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
       "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
-      "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "@types/resolve": "1.20.2",
@@ -3263,8 +3262,7 @@
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
-      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-      "dev": true
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -5708,7 +5706,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8369,8 +8366,7 @@
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-      "dev": true
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
@@ -13897,8 +13893,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "2.0.1",
@@ -14599,7 +14594,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -16153,7 +16147,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:all": "npm run test:unit && npm run test:api-live && npm run test:e2e"
   },
   "dependencies": {
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-swc": "^0.4.0",
     "@swc/core": "1.3.41",
     "@swc/helpers": "^0.5.18",
@@ -94,7 +95,6 @@
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
-    "@rollup/plugin-node-resolve": "^15.2.3",
     "@ryansonshine/commitizen": "^4.2.8",
     "@ryansonshine/cz-conventional-changelog": "^3.3.4",
     "@semantic-release/changelog": "^6.0.3",

--- a/src/rollup/build-on-the-fly.ts
+++ b/src/rollup/build-on-the-fly.ts
@@ -1,7 +1,12 @@
+import type { Plugin } from "rollup";
+
+import { existsSync, statSync } from "fs";
 import path from "path";
 
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 import rollupSwc from "@rollup/plugin-swc";
 import { remove } from "fs-extra";
+import ts from "typescript";
 
 import storyblokConfig from "../config/config.js";
 import Logger from "../utils/logger.js";
@@ -12,15 +17,118 @@ import { build } from "./setup-rollup.js";
 // Re-export for backward compatibility
 export const _extractComponentName = extractComponentName;
 
+const RESOLVE_EXTENSIONS = [".mjs", ".js", ".cjs", ".ts", ".tsx", ".json"];
+
+const getExistingFile = (filePath: string): string | null => {
+    const candidates = [
+        filePath,
+        ...RESOLVE_EXTENSIONS.map((extension) => `${filePath}${extension}`),
+        ...RESOLVE_EXTENSIONS.map((extension) =>
+            path.join(filePath, `index${extension}`),
+        ),
+    ];
+
+    for (const candidate of candidates) {
+        try {
+            if (existsSync(candidate) && statSync(candidate).isFile()) {
+                return candidate;
+            }
+        } catch {
+            // Ignore inaccessible candidates and continue resolving.
+        }
+    }
+
+    return null;
+};
+
+const getTsconfigCompilerOptions = (projectDir: string) => {
+    const configPath = ts.findConfigFile(projectDir, ts.sys.fileExists);
+
+    if (!configPath) {
+        return null;
+    }
+
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+
+    if (configFile.error) {
+        return null;
+    }
+
+    const parsed = ts.parseJsonConfigFileContent(
+        configFile.config,
+        ts.sys,
+        path.dirname(configPath),
+    );
+
+    return parsed.options;
+};
+
+const matchTsconfigPathPattern = (source: string, pattern: string) => {
+    const wildcardIndex = pattern.indexOf("*");
+
+    if (wildcardIndex === -1) {
+        return source === pattern ? "" : null;
+    }
+
+    const prefix = pattern.slice(0, wildcardIndex);
+    const suffix = pattern.slice(wildcardIndex + 1);
+
+    if (!source.startsWith(prefix) || !source.endsWith(suffix)) {
+        return null;
+    }
+
+    return source.slice(prefix.length, source.length - suffix.length);
+};
+
+const createTsconfigPathsResolver = (projectDir: string): Plugin => {
+    const compilerOptions = getTsconfigCompilerOptions(projectDir);
+    const paths = compilerOptions?.paths;
+    const baseUrl = compilerOptions?.baseUrl ?? projectDir;
+
+    return {
+        name: "sb-mig-tsconfig-paths",
+        resolveId(source) {
+            if (!paths) {
+                return null;
+            }
+
+            for (const [pattern, replacements] of Object.entries(paths)) {
+                const wildcardValue = matchTsconfigPathPattern(source, pattern);
+
+                if (wildcardValue === null) {
+                    continue;
+                }
+
+                for (const replacement of replacements) {
+                    const candidate = path.resolve(
+                        baseUrl,
+                        replacement.replace("*", wildcardValue),
+                    );
+                    const existingFile = getExistingFile(candidate);
+
+                    if (existingFile) {
+                        return existingFile;
+                    }
+                }
+            }
+
+            return null;
+        },
+    };
+};
+
 interface BuildOnTheFly {
     files: string[];
+    projectDir?: string;
 }
-export const buildOnTheFly = async ({ files }: BuildOnTheFly) => {
+export const buildOnTheFly = async ({
+    files,
+    projectDir = process.cwd(),
+}: BuildOnTheFly) => {
     if (storyblokConfig.flushCache) {
         await remove(path.join(`${storyblokConfig.cacheDir}`, `sb-mig`));
     }
 
-    const projectDir = process.cwd();
     const cacheDir = path.join(
         `${projectDir}`,
         `${storyblokConfig.cacheDir}`,
@@ -43,6 +151,11 @@ export const buildOnTheFly = async ({ files }: BuildOnTheFly) => {
                 const inputOptions = {
                     input: filePath,
                     plugins: [
+                        createTsconfigPathsResolver(projectDir),
+                        nodeResolve({
+                            extensions: RESOLVE_EXTENSIONS,
+                            preferBuiltins: true,
+                        }),
                         rollupSwc({
                             swc: {
                                 jsc: {


### PR DESCRIPTION
## Summary
- resolve extensionless TypeScript schema imports during on-the-fly Rollup compilation
- support consumer tsconfig path aliases like @/* in schema files
- move node-resolve to runtime dependencies and add regression coverage

## Validation
- npm run test:unit -- __tests__/build-on-the-fly.test.ts
- npm run build
- npm run lint -- src/rollup/build-on-the-fly.ts __tests__/build-on-the-fly.test.ts
- local fixed CLI in digital-experience-web/apps/web: sync components --all --dry-run