### PR TITLE
fix: respect component directories for selected syncs

### DIFF
--- a/__tests__/cli/discover-many.test.ts
+++ b/__tests__/cli/discover-many.test.ts
@@ -1,0 +1,95 @@
+import path from "path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { buildOnTheFlyMock, configMock, globSyncMock } = vi.hoisted(() => ({
+    buildOnTheFlyMock: vi.fn(),
+    configMock: {
+        componentsDirectories: ["src/components", "src/storyblok"],
+        schemaFileExt: "sb.js",
+        schemaType: "js",
+    },
+    globSyncMock: vi.fn((_pattern: string): string[] => []),
+}));
+
+vi.mock("../../src/config/config.js", () => ({
+    default: configMock,
+    SCHEMA: {
+        JS: "js",
+        TS: "ts",
+    },
+}));
+
+vi.mock("../../src/rollup/build-on-the-fly.js", () => ({
+    buildOnTheFly: buildOnTheFlyMock,
+}));
+
+vi.mock("../../src/utils/glob-utils.js", () => ({
+    safeGlobSync: globSyncMock,
+}));
+
+const { discoverMany, SCOPE, LOOKUP_TYPE } = await import(
+    "../../src/cli/utils/discover.js"
+);
+
+describe("discoverMany", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        configMock.componentsDirectories = ["src/components", "src/storyblok"];
+        configMock.schemaFileExt = "sb.js";
+        configMock.schemaType = "js";
+    });
+
+    it("does not search the whole project for external components when no node_modules directories are configured", async () => {
+        const result = await discoverMany({
+            scope: SCOPE.external,
+            type: LOOKUP_TYPE.fileName,
+            fileNames: ["sb-button"],
+        });
+
+        expect(result).toEqual([]);
+        expect(globSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("uses configured external component directories for selected component names", async () => {
+        if (process.platform === "win32") return expect(true).toBe(true);
+
+        configMock.componentsDirectories = [
+            "src/components",
+            "../../node_modules/@ef-global",
+            "./node_modules/@ef-global",
+        ];
+        globSyncMock.mockImplementation((pattern: string) => [pattern]);
+
+        const result = await discoverMany({
+            scope: SCOPE.external,
+            type: LOOKUP_TYPE.fileName,
+            fileNames: ["sb-button"],
+        });
+
+        const expectedPatterns = [
+            path
+                .join(
+                    process.cwd(),
+                    "../../node_modules/@ef-global",
+                    "**",
+                    "sb-button.sb.js",
+                )
+                .replace(/\\/g, "/"),
+            path
+                .join(
+                    process.cwd(),
+                    "./node_modules/@ef-global",
+                    "**",
+                    "sb-button.sb.js",
+                )
+                .replace(/\\/g, "/"),
+        ];
+
+        expect(globSyncMock).toHaveBeenCalledTimes(2);
+        expect(globSyncMock.mock.calls.map(([pattern]) => pattern)).toEqual(
+            expectedPatterns,
+        );
+        expect(result).toEqual(expectedPatterns);
+    });
+});

--- a/src/cli/utils/discover.ts
+++ b/src/cli/utils/discover.ts
@@ -52,6 +52,28 @@ interface DiscoverManyByPackageNameRequest {
 
 type DiscoverResult = string[];
 
+const discoverExactFiles = ({
+    mainDirectory,
+    componentDirectories,
+    fileNames,
+    ext,
+}: {
+    mainDirectory: string;
+    componentDirectories: string[];
+    fileNames: string[];
+    ext: string;
+}): string[] =>
+    exactFilesPatterns({
+        mainDirectory,
+        componentDirectories,
+        fileNames,
+        ext,
+    }).flatMap((exactPattern) =>
+        globSync(exactPattern.replace(/\\/g, "/"), {
+            follow: true,
+        }),
+    );
+
 // Re-export types for backwards compatibility
 export type { CompareResult, OneFileElement };
 
@@ -398,23 +420,12 @@ export const discoverMany = async (
                 );
 
             if (storyblokConfig.schemaType === SCHEMA.TS) {
-                pattern = path.join(
-                    `${directory}`,
-                    `${normalizeDiscover({
-                        segments: onlyLocalComponentsDirectories,
-                    })}`,
-                    "**",
-                    `${normalizeDiscover({ segments: request.fileNames })}.sb.${
-                        storyblokConfig.schemaType
-                    }`,
-                );
-
-                const listOfFilesToCompile = globSync(
-                    pattern.replace(/\\/g, "/"),
-                    {
-                        follow: true,
-                    },
-                );
+                const listOfFilesToCompile = discoverExactFiles({
+                    mainDirectory: directory,
+                    componentDirectories: onlyLocalComponentsDirectories,
+                    fileNames: request.fileNames,
+                    ext: `sb.${storyblokConfig.schemaType}`,
+                });
 
                 await buildOnTheFly({ files: listOfFilesToCompile });
 
@@ -437,19 +448,11 @@ export const discoverMany = async (
                 );
             }
 
-            pattern = path.join(
-                `${directory}`,
-                `${normalizeDiscover({
-                    segments: onlyLocalComponentsDirectories,
-                })}`,
-                "**",
-                `${normalizeDiscover({ segments: request.fileNames })}.${
-                    storyblokConfig.schemaFileExt
-                }`,
-            );
-
-            listOfFiles = globSync(pattern.replace(/\\/g, "/"), {
-                follow: true,
+            listOfFiles = discoverExactFiles({
+                mainDirectory: directory,
+                componentDirectories: onlyLocalComponentsDirectories,
+                fileNames: request.fileNames,
+                ext: storyblokConfig.schemaFileExt,
             });
             listOfFiles = [...listOfFiles, ...listOFSchemaTSFilesCompiled];
             break;
@@ -460,19 +463,12 @@ export const discoverMany = async (
                 storyblokConfig.componentsDirectories.filter((p: string) =>
                     p.includes("node_modules"),
                 );
-            pattern = path.join(
-                `${directory}`,
-                `${normalizeDiscover({
-                    segments: onlyNodeModulesPackagesComponentsDirectories,
-                })}`,
-                "**",
-                `${normalizeDiscover({ segments: request.fileNames })}.${
-                    storyblokConfig.schemaFileExt
-                }`,
-            );
-
-            listOfFiles = globSync(pattern.replace(/\\/g, "/"), {
-                follow: true,
+            listOfFiles = discoverExactFiles({
+                mainDirectory: directory,
+                componentDirectories:
+                    onlyNodeModulesPackagesComponentsDirectories,
+                fileNames: request.fileNames,
+                ext: storyblokConfig.schemaFileExt,
             });
             break;
         case SCOPE.lock:
@@ -480,19 +476,11 @@ export const discoverMany = async (
 
         case SCOPE.all:
             // ### MANY - ALL - fileName ###
-            pattern = path.join(
-                `${directory}`,
-                `${normalizeDiscover({
-                    segments: storyblokConfig.componentsDirectories,
-                })}`,
-                "**",
-                `${normalizeDiscover({ segments: request.fileNames })}.${
-                    storyblokConfig.schemaFileExt
-                }`,
-            );
-
-            listOfFiles = globSync(pattern.replace(/\\/g, "/"), {
-                follow: true,
+            listOfFiles = discoverExactFiles({
+                mainDirectory: directory,
+                componentDirectories: storyblokConfig.componentsDirectories,
+                fileNames: request.fileNames,
+                ext: storyblokConfig.schemaFileExt,
             });
             break;
 


### PR DESCRIPTION
## Summary
- fix selected component discovery to use exact per-directory glob patterns
- avoid falling back to whole-project search when no external component directory is configured
- add regression coverage for selected component sync directory handling

## Manual verification
1. In a test project, configure `storyblok.config.js` with multiple `componentsDirectories`, for example `node_modules/@ef-global`, `src/components`, and `src/storyblok`.
2. Add or keep a local schema such as `src/storyblok/sb-button.sb.js`; optionally keep another `sb-button.sb.js` under the configured package path to verify local precedence.
3. Run `sb-mig sync components sb-button --dry-run` or run against a disposable Storyblok space.
4. Confirm the selected sync resolves `sb-button` only from the configured directories and prefers the local file when a matching external file exists.
5. Run `sb-mig sync components --all --dry-run` and confirm directory handling remains consistent with the selected-component command.

## Validation
- npm run test:unit -- __tests__/cli/discover-many.test.ts __tests__/discover.test.ts
- npm run typecheck
- npm run lint
- npm run test:unit

Fixes #289
Closes MAR-978