### PR TITLE
fix: tolerate SSOT default content type removal

### DIFF
--- a/__tests__/api/sync-components-ssot.test.ts
+++ b/__tests__/api/sync-components-ssot.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { syncComponentsData } from "../../src/api/components/components.sync.js";
+import Logger from "../../src/utils/logger.js";
+import {
+    createMockApiConfig,
+    createPaginatedResponse,
+} from "../mocks/storyblokClient.mock.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+describe("sync components SSOT", () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        consoleErrorSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("continues syncing when a remote component cannot be removed", async () => {
+        const config = createMockApiConfig();
+        let componentReads = 0;
+
+        config.sbApi.get.mockImplementation((path: string) => {
+            if (path.includes("component_groups")) {
+                return Promise.resolve(
+                    createPaginatedResponse([], "component_groups"),
+                );
+            }
+
+            componentReads++;
+            const components =
+                componentReads === 1
+                    ? [
+                          { id: 1, name: "page" },
+                          { id: 2, name: "obsolete" },
+                      ]
+                    : [{ id: 1, name: "page" }];
+
+            return Promise.resolve(
+                createPaginatedResponse(components, "components"),
+            );
+        });
+
+        config.sbApi.delete.mockImplementation((path: string) => {
+            if (path.includes("/components/1")) {
+                return Promise.reject(
+                    new Error("Cannot delete default content type"),
+                );
+            }
+
+            return Promise.resolve({ data: {} });
+        });
+        config.sbApi.put.mockResolvedValue({ data: {} });
+        config.sbApi.post.mockResolvedValue({ data: {} });
+
+        const result = await syncComponentsData(
+            {
+                components: [{ name: "page" }, { name: "card" }],
+                presets: false,
+                ssot: true,
+            },
+            config,
+        );
+
+        expect(config.sbApi.delete).toHaveBeenCalledTimes(2);
+        expect(config.sbApi.put).toHaveBeenCalledWith(
+            "spaces/12345/components/1",
+            { component: { id: 1, name: "page", component_group_uuid: null } },
+        );
+        expect(config.sbApi.post).toHaveBeenCalledWith(
+            "spaces/12345/components/",
+            { component: { name: "card", component_group_uuid: null } },
+        );
+        expect(result.created).toEqual(["card"]);
+        expect(result.updated).toEqual(["page"]);
+        expect(result.skipped).toEqual(["component 'page'"]);
+        expect(result.errors).toEqual([
+            {
+                name: "component 'page'",
+                message:
+                    "SSOT removal failed: Cannot delete default content type",
+            },
+        ]);
+        expect(Logger.warning).toHaveBeenCalledWith(
+            "Could not remove component 'page' during SSOT sync: Cannot delete default content type",
+        );
+    });
+});

--- a/src/api/components/components.sync.ts
+++ b/src/api/components/components.sync.ts
@@ -46,6 +46,16 @@ import {
     updateComponent,
 } from "./components.js";
 
+type RemovalTarget = {
+    type: "component" | "component group";
+    name: string;
+    remove: () => Promise<any>;
+};
+
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
 async function ensureComponentGroupsExist(
     groupNames: string[],
     config: RequestBaseConfig,
@@ -129,14 +139,41 @@ export async function syncComponentsData(
                 );
             }
         } else {
-            await Promise.allSettled([
-                ...(existingComponents ?? []).map((c: any) =>
-                    removeComponent(c, config),
-                ),
-                ...(existingGroups ?? []).map((g: any) =>
-                    removeComponentGroup(g, config),
-                ),
-            ]);
+            const removalTargets: RemovalTarget[] = [
+                ...(existingComponents ?? []).map((component: any) => ({
+                    type: "component" as const,
+                    name: String(component?.name ?? component?.id ?? "unknown"),
+                    remove: () => removeComponent(component, config),
+                })),
+                ...(existingGroups ?? []).map((group: any) => ({
+                    type: "component group" as const,
+                    name: String(group?.name ?? group?.id ?? "unknown"),
+                    remove: () => removeComponentGroup(group, config),
+                })),
+            ];
+
+            const removalResults = await Promise.allSettled(
+                removalTargets.map((target) => target.remove()),
+            );
+
+            removalResults.forEach((removalResult, index) => {
+                if (removalResult.status === "fulfilled") return;
+
+                const target = removalTargets[index];
+                if (!target) return;
+
+                const name = `${target.type} '${target.name}'`;
+                const message = getErrorMessage(removalResult.reason);
+
+                result.skipped.push(name);
+                result.errors.push({
+                    name,
+                    message: `SSOT removal failed: ${message}`,
+                });
+                Logger.warning(
+                    `Could not remove ${name} during SSOT sync: ${message}`,
+                );
+            });
         }
     }
 
@@ -241,7 +278,7 @@ export async function syncComponentsData(
         } catch (error) {
             result.errors.push({
                 name,
-                message: error instanceof Error ? error.message : String(error),
+                message: getErrorMessage(error),
             });
             progress({
                 type: "progress",
@@ -249,7 +286,7 @@ export async function syncComponentsData(
                 total: totalComponents,
                 name,
                 action: "error",
-                message: error instanceof Error ? error.message : String(error),
+                message: getErrorMessage(error),
             });
         }
     }
@@ -293,7 +330,7 @@ export async function syncComponentsData(
         } catch (error) {
             result.errors.push({
                 name,
-                message: error instanceof Error ? error.message : String(error),
+                message: getErrorMessage(error),
             });
             progress({
                 type: "progress",
@@ -301,7 +338,7 @@ export async function syncComponentsData(
                 total: totalComponents,
                 name,
                 action: "error",
-                message: error instanceof Error ? error.message : String(error),
+                message: getErrorMessage(error),
             });
         }
     }

--- a/src/api/components/components.ts
+++ b/src/api/components/components.ts
@@ -151,7 +151,10 @@ export const removeComponent: RemoveComponent = (component, config) => {
     return sbApi
         .delete(`spaces/${spaceId}/components/${id}`, {})
         .then((res: any) => res.data)
-        .catch((err: any) => console.error(err));
+        .catch((err: any) => {
+            console.error(err);
+            throw err;
+        });
 };
 
 /*
@@ -221,7 +224,10 @@ export const removeComponentGroup: RemoveComponentGroup = (
     return sbApi
         .delete(`spaces/${spaceId}/component_groups/${id}`, {})
         .then((res: any) => res.data)
-        .catch((err: any) => console.error(err));
+        .catch((err: any) => {
+            console.error(err);
+            throw err;
+        });
 };
 
 export const createComponentsGroup: CreateComponentsGroup = (

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -3,7 +3,6 @@ import type { SyncDirection } from "../sync.types.js";
 
 import { managementApi } from "../../api/managementApi.js";
 import {
-    removeAllComponents,
     syncAllComponents,
     syncContent,
     syncProvidedComponents,
@@ -115,8 +114,9 @@ export const sync = async (props: CLIOptions) => {
                     await askForConfirmation(
                         "Are you sure you want to use Single Source of truth? It will remove all your components added in GUI and replace them 1 to 1 with code versions.",
                         async () => {
-                            await removeAllComponents(apiConfig);
-                            await syncAllComponents(presets, apiConfig);
+                            await syncAllComponents(presets, apiConfig, {
+                                ssot: true,
+                            });
                         },
                         () => {
                             Logger.success("Syncing components aborted.");


### PR DESCRIPTION
## Summary
- route real `sync components --all --ssot` through the shared SSOT sync path
- collect and report failed SSOT removals while continuing component create/update work
- rethrow component/group delete failures so tolerant SSOT removal can classify skipped items
- add regression coverage for a default content type deletion failure

## Verification
- `npm run test:unit -- __tests__/api/sync-components-ssot.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `npm run lint`

Linear: MAR-979