### PR TITLE
feat(assets): expose create and update helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,40 @@ module.exports = {
 };
 ```
 
+## Programmatic asset API
+
+The public management API exposes asset helpers for uploading a local file and updating existing asset metadata:
+
+```ts
+import { managementApi } from "sb-mig/dist/api/managementApi.js";
+
+await managementApi.assets.createAsset(
+  {
+    spaceId: "12345",
+    pathToFile: "./public/image.jpg",
+    payload: {
+      asset_folder_id: 67890,
+      validate_upload: 1,
+    },
+  },
+  config,
+);
+
+await managementApi.assets.updateAsset(
+  {
+    spaceId: "12345",
+    assetId: 98765,
+    payload: {
+      meta_data: {
+        alt: "Image alt text",
+        title: "Image title",
+      },
+    },
+  },
+  config,
+);
+```
+
 # Schema documentation:
 
 ## Basics

--- a/__tests__/api/assets.test.ts
+++ b/__tests__/api/assets.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const formDataMock = vi.hoisted(() => ({
+    instances: [] as Array<{
+        fields: Array<[string, unknown]>;
+        submitUrl?: string;
+    }>,
+    statusCode: 204,
+}));
+
+vi.mock("form-data", () => {
+    class MockFormData {
+        fields: Array<[string, unknown]> = [];
+        submitUrl?: string;
+
+        constructor() {
+            formDataMock.instances.push(this);
+        }
+
+        append(key: string, value: unknown) {
+            this.fields.push([key, value]);
+        }
+
+        submit(
+            url: string,
+            callback: (
+                error: Error | null,
+                response?: { statusCode?: number },
+            ) => void,
+        ) {
+            this.submitUrl = url;
+            callback(null, { statusCode: formDataMock.statusCode });
+        }
+    }
+
+    return { default: MockFormData };
+});
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+        upload: vi.fn(),
+        download: vi.fn(),
+    },
+}));
+
+import { createAsset, updateAsset } from "../../src/api/assets/index.js";
+import { managementApi } from "../../src/api/managementApi.js";
+
+describe("Assets API", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        formDataMock.instances.length = 0;
+        formDataMock.statusCode = 204;
+    });
+
+    it("exposes createAsset and updateAsset through managementApi.assets", () => {
+        expect(managementApi.assets.createAsset).toBe(createAsset);
+        expect(managementApi.assets.updateAsset).toBe(updateAsset);
+    });
+
+    it("creates an asset by requesting a signed upload and submitting the file", async () => {
+        const signedResponseObject = {
+            post_url: "https://s3.example.com/upload",
+            fields: {
+                key: "f/123/asset.jpg",
+                policy: "signed-policy",
+            },
+        };
+        const sbApi = {
+            post: vi.fn().mockResolvedValue({ data: signedResponseObject }),
+        };
+
+        const result = await createAsset(
+            {
+                spaceId: "12345",
+                pathToFile: "README.md",
+                payload: {
+                    filename: "folder/asset.jpg",
+                    asset_folder_id: 42,
+                    size: "100x200",
+                    validate_upload: 1,
+                },
+            },
+            { spaceId: "12345", sbApi: sbApi as any },
+        );
+
+        expect(result).toBe(signedResponseObject);
+        expect(sbApi.post).toHaveBeenCalledWith("spaces/12345/assets/", {
+            filename: "asset.jpg",
+            asset_folder_id: 42,
+            size: "100x200",
+            validate_upload: 1,
+        });
+
+        expect(formDataMock.instances).toHaveLength(1);
+        expect(formDataMock.instances[0]?.submitUrl).toBe(
+            "https://s3.example.com/upload",
+        );
+        expect(formDataMock.instances[0]?.fields).toEqual([
+            ["key", "f/123/asset.jpg"],
+            ["policy", "signed-policy"],
+            ["file", expect.any(Object)],
+        ]);
+    });
+
+    it("uses the local file name when createAsset payload omits filename", async () => {
+        const sbApi = {
+            post: vi.fn().mockResolvedValue({
+                data: {
+                    post_url: "https://s3.example.com/upload",
+                    fields: {},
+                },
+            }),
+        };
+
+        await createAsset(
+            {
+                spaceId: "12345",
+                pathToFile: "./sb-mig-logo.png",
+            },
+            { spaceId: "12345", sbApi: sbApi as any },
+        );
+
+        expect(sbApi.post).toHaveBeenCalledWith("spaces/12345/assets/", {
+            filename: "sb-mig-logo.png",
+        });
+    });
+
+    it("updates asset metadata with Storyblok's asset update payload", async () => {
+        const updateResponse = {
+            data: {
+                asset: {
+                    id: 987,
+                    meta_data: { alt: "Updated alt text" },
+                },
+            },
+        };
+        const sbApi = {
+            put: vi.fn().mockResolvedValue(updateResponse),
+        };
+
+        const result = await updateAsset(
+            {
+                spaceId: "12345",
+                assetId: 987,
+                payload: {
+                    asset_folder_id: 456,
+                    internal_tag_ids: [1111],
+                    is_private: true,
+                    locked: false,
+                    meta_data: {
+                        alt: "Updated alt text",
+                        title: "Updated title",
+                    },
+                    publish_at: "2026-05-31T11:52:00.000Z",
+                },
+            },
+            { spaceId: "12345", sbApi: sbApi as any },
+        );
+
+        expect(result).toBe(updateResponse.data);
+        expect(sbApi.put).toHaveBeenCalledWith("spaces/12345/assets/987", {
+            asset_folder_id: 456,
+            internal_tag_ids: [1111],
+            is_private: true,
+            locked: false,
+            meta_data: {
+                alt: "Updated alt text",
+                title: "Updated title",
+            },
+            publish_at: "2026-05-31T11:52:00.000Z",
+        });
+    });
+});

--- a/src/api/assets/assets.ts
+++ b/src/api/assets/assets.ts
@@ -1,9 +1,12 @@
 import type {
+    CreateAsset,
     GetAllAssets,
     GetAssetById,
     GetAssetByName,
     MigrateAsset,
     RequestSignedUploadUrl,
+    SignedUploadPayload,
+    UpdateAsset,
     UploadFile,
     DownloadAsset,
 } from "./assets.types.js";
@@ -17,6 +20,30 @@ import FormData from "form-data";
 import { createDir, isDirectoryExists } from "../../utils/files.js";
 import Logger from "../../utils/logger.js";
 import { getFileName, getSizeFromURL } from "../../utils/string-utils.js";
+
+const isStoryblokSize = (size: string | undefined): size is string =>
+    Boolean(size && /^\d+x\d+$/i.test(size));
+
+const prepareSignedUploadPayload = (
+    payload: SignedUploadPayload,
+): SignedUploadPayload => {
+    const { filename, asset_folder_id, id, size, validate_upload } = payload;
+    const inferredSize = isStoryblokSize(size)
+        ? size
+        : isStoryblokSize(getSizeFromURL(filename))
+          ? getSizeFromURL(filename)
+          : undefined;
+
+    return {
+        filename: getFileName(filename),
+        ...(asset_folder_id === undefined || asset_folder_id === null
+            ? {}
+            : { asset_folder_id }),
+        ...(id === undefined ? {} : { id }),
+        ...(inferredSize ? { size: inferredSize } : {}),
+        ...(validate_upload === undefined ? {} : { validate_upload }),
+    };
+};
 
 // GET
 export const getAllAssets: GetAllAssets = async (args, config) => {
@@ -60,26 +87,13 @@ const requestSignedUploadUrl: RequestSignedUploadUrl = (
     config,
 ) => {
     const { sbApi, debug } = config;
-    const {
-        filename: _1,
-        asset_folder_id,
-        ext_id,
-        space_id,
-        deleted_at: _2,
-        ...restPayload
-    } = payload;
-    const filename = getFileName(payload.filename);
-    const size = getSizeFromURL(payload.filename);
+    const signedUploadPayload = prepareSignedUploadPayload(payload);
     return sbApi
-        .post(`spaces/${spaceId}/assets/`, {
-            filename,
-            size,
-            ...restPayload,
-        })
+        .post(`spaces/${spaceId}/assets/`, signedUploadPayload)
         .then((signedResponseObject) => {
             if (debug) {
                 Logger.log(
-                    `Signed upload URL has been requested for ${filename}.`,
+                    `Signed upload URL has been requested for ${signedUploadPayload.filename}.`,
                 );
             }
             return (signedResponseObject as any as { data: any }).data; // this is very bad... but storyblok-js-client types are pretty broken
@@ -102,13 +116,28 @@ const uploadFile: UploadFile = ({ signedResponseObject, pathToFile }) => {
     form.append("file", fs.createReadStream(file));
 
     // submit your form
-    form.submit(signedResponseObject.post_url, async (err, res) => {
-        const statusCode = res.statusCode;
-        if (statusCode === 204) {
-            Logger.upload(`Asset uploaded ${getFileName(file)}`);
-        } else {
-            if (err) throw err;
-        }
+    return new Promise<void>((resolve, reject) => {
+        form.submit(signedResponseObject.post_url, (err, res) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            const statusCode = res?.statusCode;
+            if (statusCode === 204) {
+                Logger.upload(`Asset uploaded ${getFileName(file)}`);
+                resolve();
+                return;
+            }
+
+            reject(
+                new Error(
+                    `Asset upload failed with status code ${
+                        statusCode ?? "unknown"
+                    }`,
+                ),
+            );
+        });
     });
 };
 
@@ -179,6 +208,47 @@ export const migrateAsset: MigrateAsset = async (
     }
 
     return true;
+};
+
+export const createAsset: CreateAsset = async (
+    { spaceId, pathToFile, payload = {} },
+    config,
+) => {
+    const signedResponseObject = await requestSignedUploadUrl(
+        {
+            spaceId,
+            payload: {
+                ...payload,
+                filename: payload.filename ?? pathToFile,
+            },
+        },
+        config,
+    );
+
+    await uploadFile({ signedResponseObject, pathToFile });
+
+    return signedResponseObject;
+};
+
+export const updateAsset: UpdateAsset = async (
+    { spaceId, assetId, payload },
+    config,
+) => {
+    const { sbApi } = config;
+    Logger.log(`Trying to update asset with id ${assetId}.`);
+
+    return sbApi
+        .put(`spaces/${spaceId}/assets/${assetId}`, payload)
+        .then((res: any) => {
+            Logger.success(`Asset '${assetId}' has been updated.`);
+            return res.data;
+        })
+        .catch((err: any) => {
+            Logger.error(
+                `${err.message} in updateAsset function for asset ${assetId}`,
+            );
+            throw err;
+        });
 };
 
 // GET

--- a/src/api/assets/assets.types.ts
+++ b/src/api/assets/assets.types.ts
@@ -41,6 +41,33 @@ export interface SBAllAssetRequestResult {
 export type SignedResponseObject = any;
 export type AssetPayload = Omit<SBAsset, "updated_at" | "created_at" | "id">;
 
+export interface SignedUploadPayload {
+    filename: string;
+    id?: number;
+    asset_folder_id?: number | null;
+    size?: string;
+    validate_upload?: number;
+}
+
+export type CreateAssetPayload = Omit<SignedUploadPayload, "filename" | "id"> &
+    Partial<Pick<SignedUploadPayload, "filename">>;
+
+export type UpdateAssetPayload = {
+    asset_folder_id?: number | null;
+    internal_tag_ids?: number[];
+    is_private?: boolean;
+    locked?: boolean;
+    meta_data?: {
+        alt?: string;
+        copyright?: string;
+        source?: string;
+        title?: string;
+        [key: string]: unknown;
+    };
+    publish_at?: string | null;
+    [key: string]: unknown;
+};
+
 export type GetAllAssets = (
     {
         spaceId,
@@ -82,13 +109,37 @@ export type MigrateAsset = (
     },
     config: RequestBaseConfig,
 ) => Promise<boolean>;
+export type CreateAsset = (
+    {
+        spaceId,
+        pathToFile,
+        payload,
+    }: {
+        spaceId: string;
+        pathToFile: string;
+        payload?: CreateAssetPayload;
+    },
+    config: RequestBaseConfig,
+) => Promise<SignedResponseObject>;
+export type UpdateAsset = (
+    {
+        spaceId,
+        assetId,
+        payload,
+    }: {
+        spaceId: string;
+        assetId: number;
+        payload: UpdateAssetPayload;
+    },
+    config: RequestBaseConfig,
+) => Promise<any>;
 export type UploadFile = ({
     signedResponseObject,
     pathToFile,
 }: {
     signedResponseObject: SignedResponseObject;
     pathToFile: string;
-}) => void;
+}) => Promise<void>;
 export type FinalizeUpload = ({
     signedResponseObject,
 }: {
@@ -101,7 +152,7 @@ export type RequestSignedUploadUrl = (
         payload,
     }: {
         spaceId: string;
-        payload: AssetPayload;
+        payload: AssetPayload | SignedUploadPayload;
     },
     config: RequestBaseConfig,
 ) => Promise<any>;

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -1,7 +1,15 @@
 export {
     getAllAssets,
+    createAsset,
     migrateAsset,
     getAsset,
     getAssetById,
     getAssetByName,
+    updateAsset,
 } from "./assets.js";
+
+export type {
+    CreateAssetPayload,
+    SignedUploadPayload,
+    UpdateAssetPayload,
+} from "./assets.types.js";


### PR DESCRIPTION
## Summary
- add public createAsset and updateAsset helpers to managementApi.assets
- reuse the signed-upload flow and make uploads awaitable for create/migrate paths
- add asset API regression tests and README usage examples

## Validation
- npm run test -- __tests__/api/assets.test.ts
- npm run test:unit
- npm run typecheck
- npm run lint
- git diff --check

## Manual verification
1. Build the package locally with npm run build.
2. Configure a Storyblok management client with a test space and OAuth token.
3. Call managementApi.assets.createAsset with a small local image file and confirm the asset appears in the target space.
4. Call managementApi.assets.updateAsset for the created asset ID with meta_data.alt or meta_data.title and confirm the metadata changes in Storyblok.
5. Optionally run an existing asset migration flow and confirm assets still upload successfully.

Closes #301
Linear: MAR-976