### PR TITLE
fix(discover): normalize Windows component paths

### DIFF
--- a/__tests__/utils/path-utils.test.ts
+++ b/__tests__/utils/path-utils.test.ts
@@ -186,6 +186,24 @@ describe("path-utils", () => {
 
                 expect(result.local[0].name).toBe("hero.sb.js");
             });
+
+            it("should extract filename from Windows paths regardless of runtime OS", () => {
+                const result = compare({
+                    local: [
+                        "C:\\Users\\PaddyEvans\\Documents\\Tickets\\project\\src\\components\\hero.sb.js",
+                        "C:/Users/PaddyEvans/Documents/Tickets/project/.next/cache/sb-mig/card.sb.cjs",
+                    ],
+                    external: [
+                        "C:\\Users\\PaddyEvans\\Documents\\Tickets\\project\\node_modules\\@ef-global\\backpack\\lib\\components\\Accordion\\storyblok\\sb-accordion.sb.cjs",
+                    ],
+                });
+
+                expect(result.local.map((file) => file.name)).toEqual([
+                    "hero.sb.js",
+                    "card.sb.cjs",
+                ]);
+                expect(result.external[0].name).toBe("sb-accordion.sb.cjs");
+            });
         });
 
         describe("deduplication", () => {

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import {
+    mkdir,
+    mkdtemp,
+    readdir,
+    readFile,
+    rm,
+    writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -192,6 +199,42 @@ const main = async () => {
         if (!discover.stdout.includes("hero")) {
             throw new Error(
                 `Expected discover output to include the hero component:\n${discover.stdout}`,
+            );
+        }
+
+        await runNpm(
+            [
+                "exec",
+                "--",
+                "sb-mig",
+                "discover",
+                "components",
+                "--all",
+                "--write",
+                "--file",
+                "all-components",
+            ],
+            { cwd: projectDir, env: npmEnv },
+        );
+
+        const componentListPath = path.join(
+            projectDir,
+            "sbmig",
+            "all-components.ts",
+        );
+        const componentList = await readFile(componentListPath, "utf8");
+        const normalizedComponentList = componentList.replace(/\\/g, "/");
+        const normalizedProjectDir = projectDir.replace(/\\/g, "/");
+
+        if (!componentList.includes('"hero"')) {
+            throw new Error(
+                `Expected generated component list to include only the hero component name:\n${componentList}`,
+            );
+        }
+
+        if (normalizedComponentList.includes(normalizedProjectDir)) {
+            throw new Error(
+                `Generated component list should not include full project paths:\n${componentList}`,
             );
         }
 

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -26,6 +26,11 @@ export const extractComponentName = (filePath: string): string => {
     return lastElement.replace(/\.ts$/, "");
 };
 
+const getFileName = (filePath: string): string => {
+    const normalized = filePath.replace(/\\/g, "/");
+    return normalized.substring(normalized.lastIndexOf("/") + 1);
+};
+
 /**
  * Represents a file element with its name and path
  */
@@ -175,7 +180,7 @@ export const compare = (request: CompareRequest): CompareResult => {
     const { local, external } = request;
 
     const splittedLocal = local.map((p) => ({
-        name: path.basename(p),
+        name: getFileName(p),
         p,
     }));
 
@@ -183,7 +188,7 @@ export const compare = (request: CompareRequest): CompareResult => {
 
     const splittedExternal = external
         .map((p) => ({
-            name: path.basename(p),
+            name: getFileName(p),
             p,
         }))
         .filter((file) => {


### PR DESCRIPTION
## Summary
- normalize discovered component filenames from Windows-style paths before building the component list
- add regression coverage for `C:\...` and `C:/...` component paths
- strengthen package smoke coverage so `discover components --all --write` fails if full project paths are written to `all-components.ts`

## Release / changeset
- Non-empty conventional `fix(discover)` commit pushed: `4283a37`
- This repo uses semantic-release rather than Changesets; the conventional fix commit is the release signal.

## Validation
- `npm run test:unit -- __tests__/utils/path-utils.test.ts __tests__/cli/discover-many.test.ts __tests__/build-on-the-fly.test.ts`
- `npm run typecheck`
- `npm run build`
- `node scripts/package-smoke.mjs sb-mig-6.0.0.tgz`
- `npm run lint`