### PR TITLE
fix(api): encode query parameters with URLSearchParams

### DIFF
--- a/__tests__/api/contentHubApi.test.ts
+++ b/__tests__/api/contentHubApi.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { contentHubApi } from "../../src/api/contentHubApi.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+describe("contentHubApi", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("fetches stories with encoded query params and auth header", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue({
+                ok: true,
+                json: async () => ({ stories: [] }),
+            } as Response);
+
+        await contentHubApi.getAllStories(
+            {
+                spaceId: "12345",
+                storiesFilename: "folder/story name & draft?.json",
+            },
+            {
+                contentHubOriginUrl: "https://content-hub.example.com/api/hub/",
+                contentHubAuthorizationToken: "token",
+                spaceId: "12345",
+                sbApi: {} as any,
+            },
+        );
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://content-hub.example.com/api/hub/getStories?spaceId=12345&storiesFilename=folder%2Fstory+name+%26+draft%3F.json",
+            {
+                method: "GET",
+                headers: {
+                    Authorization: "token",
+                },
+            },
+        );
+    });
+
+    it("does not serialize missing storiesFilename as undefined", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue({
+                ok: true,
+                json: async () => ({ stories: [] }),
+            } as Response);
+
+        await contentHubApi.getAllStories(
+            {
+                spaceId: "12345",
+            },
+            {
+                contentHubOriginUrl: "https://content-hub.example.com/api/hub",
+                contentHubAuthorizationToken: "token",
+                spaceId: "12345",
+                sbApi: {} as any,
+            },
+        );
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://content-hub.example.com/api/hub/getStories?spaceId=12345",
+            expect.any(Object),
+        );
+    });
+});

--- a/__tests__/utils/url-utils.test.ts
+++ b/__tests__/utils/url-utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { buildUrl } from "../../src/utils/url-utils.js";
+
+describe("buildUrl", () => {
+    it("builds URLs with encoded search params", () => {
+        const url = buildUrl({
+            baseUrl: "https://content-hub.example.com/api/hub/",
+            pathname: "getStories",
+            searchParams: {
+                spaceId: "12345",
+                storiesFilename: "folder/story name & draft?.json",
+            },
+        });
+
+        expect(url.toString()).toBe(
+            "https://content-hub.example.com/api/hub/getStories?spaceId=12345&storiesFilename=folder%2Fstory+name+%26+draft%3F.json",
+        );
+        expect(url.searchParams.get("storiesFilename")).toBe(
+            "folder/story name & draft?.json",
+        );
+    });
+
+    it("omits nullish search params without dropping empty strings", () => {
+        const url = buildUrl({
+            baseUrl: "https://localhost:3000",
+            pathname: "/api/preview/preview",
+            searchParams: {
+                secret: "abc+123",
+                slug: "",
+                missing: undefined,
+                empty: null,
+            },
+        });
+
+        expect(url.toString()).toBe(
+            "https://localhost:3000/api/preview/preview?secret=abc%2B123&slug=",
+        );
+    });
+
+    it("appends the pathname consistently when the base URL has no trailing slash", () => {
+        const url = buildUrl({
+            baseUrl: "https://content-hub.example.com/api/hub",
+            pathname: "/getStories",
+            searchParams: {
+                spaceId: "12345",
+            },
+        });
+
+        expect(url.toString()).toBe(
+            "https://content-hub.example.com/api/hub/getStories?spaceId=12345",
+        );
+    });
+});

--- a/src/api/contentHubApi.ts
+++ b/src/api/contentHubApi.ts
@@ -1,6 +1,7 @@
 import type { RequestBaseConfig } from "./utils/request.js";
 
 import Logger from "../utils/logger.js";
+import { buildUrl } from "../utils/url-utils.js";
 
 type GetAllStories = (
     args: {
@@ -14,15 +15,25 @@ const getAllStories: GetAllStories = async (args, config) => {
     const { spaceId, storiesFilename } = args;
 
     Logger.warning("Trying to get all stories from Content Hub...");
-    const queryParams = `spaceId=${spaceId}&storiesFilename=${storiesFilename}`;
-    const url = `${config.contentHubOriginUrl}/getStories?${queryParams}`;
+    if (!config.contentHubOriginUrl) {
+        throw new Error("contentHubOriginUrl is required to fetch stories.");
+    }
+
+    const url = buildUrl({
+        baseUrl: config.contentHubOriginUrl,
+        pathname: "getStories",
+        searchParams: {
+            spaceId,
+            ...(storiesFilename ? { storiesFilename } : {}),
+        },
+    });
     const authorizationToken = config.contentHubAuthorizationToken;
     if (config.debug) {
-        console.log("This is url: ", url);
+        console.log("This is url: ", url.toString());
     }
 
     try {
-        const response = await fetch(url, {
+        const response = await fetch(url.toString(), {
             method: "GET",
             headers: {
                 Authorization: authorizationToken as string,

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 import { managementApi } from "../../api/managementApi.js";
 import { storyblokApiMapping } from "../../config/constants.js";
 import Logger from "../../utils/logger.js";
+import { buildUrl } from "../../utils/url-utils.js";
 import { apiConfig } from "../api-config.js";
 
 const INIT_COMMANDS = {
@@ -97,11 +98,20 @@ export const init = async (props: CLIOptions) => {
             }
 
             try {
+                const previewDomainUrl = buildUrl({
+                    baseUrl: "https://localhost:3000",
+                    pathname: "api/preview/preview",
+                    searchParams: {
+                        secret: STORYBLOK_PREVIEW_SECRET,
+                        slug: "",
+                    },
+                });
+
                 await managementApi.spaces.updateSpace(
                     {
                         spaceId,
                         params: {
-                            domain: `https://localhost:3000/api/preview/preview?secret=${STORYBLOK_PREVIEW_SECRET}&slug=`,
+                            domain: previewDomainUrl.toString(),
                         },
                     },
                     { ...apiConfig, sbApi: localSbApi },

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,0 +1,34 @@
+export type SearchParamValue = string | number | boolean | null | undefined;
+
+type BuildUrlArgs = {
+    baseUrl: string;
+    pathname?: string;
+    searchParams?: Record<string, SearchParamValue>;
+};
+
+const withTrailingSlash = (value: string): string =>
+    value.endsWith("/") ? value : `${value}/`;
+
+const normalizePathname = (pathname = ""): string =>
+    pathname.replace(/^\/+/, "");
+
+export const buildUrl = ({
+    baseUrl,
+    pathname,
+    searchParams = {},
+}: BuildUrlArgs): URL => {
+    const url = new URL(
+        normalizePathname(pathname),
+        withTrailingSlash(baseUrl),
+    );
+
+    for (const [key, value] of Object.entries(searchParams)) {
+        if (value === undefined || value === null) {
+            continue;
+        }
+
+        url.searchParams.set(key, String(value));
+    }
+
+    return url;
+};


### PR DESCRIPTION
## Summary
- add a shared URL builder that encodes query params with native URLSearchParams
- update Content Hub story fetching and preview-domain generation to avoid manual query strings
- add tests for special-character filenames, nullish params, and fetch URL behavior

## Validation
- npm run typecheck
- npm run lint
- npm run test:unit