### PR TITLE
fix: use Storyblok client for language state checks

### DIFF
--- a/__tests__/api/language-publish-state.test.ts
+++ b/__tests__/api/language-publish-state.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { storyblokClientConstructorMock, storyblokGetMock } = vi.hoisted(() => ({
+    storyblokClientConstructorMock: vi.fn(),
+    storyblokGetMock: vi.fn(),
+}));
+
+vi.mock("storyblok-js-client", () => ({
+    default: vi.fn().mockImplementation((config, endpoint) => {
+        storyblokClientConstructorMock(config, endpoint);
+
+        return {
+            get: storyblokGetMock,
+        };
+    }),
+}));
+
+import {
+    buildLanguagePublishStateMapFromStories,
+    createStatusPreservingFetch,
+} from "../../src/api/stories/language-publish-state.js";
+
+const createStoryItem = () => ({
+    story: {
+        id: "story-1",
+        uuid: "uuid-1",
+        name: "Contact Us",
+        full_slug: "translation-migration-testing/test-1/contact-us",
+        is_folder: false,
+        published: true,
+        unpublished_changes: false,
+        published_at: "2026-05-20T10:00:00.000Z",
+        first_published_at: "2026-05-20T09:00:00.000Z",
+        content: {
+            component: "page",
+            body: [],
+        },
+    },
+});
+
+describe("buildLanguagePublishStateMapFromStories", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("uses the Storyblok delivery client instead of raw fetch for translated language checks", async () => {
+        const content = {
+            component: "page",
+            body: [{ component: "target", text: "Published French" }],
+        };
+
+        storyblokGetMock.mockResolvedValue({
+            data: {
+                story: {
+                    full_slug:
+                        "fr/translation-migration-testing/test-1/contact-us",
+                    published_at: "2026-05-20T10:00:00.000Z",
+                    content,
+                },
+            },
+        });
+
+        const result = await buildLanguagePublishStateMapFromStories(
+            {
+                from: "space-1",
+                stories: [createStoryItem()],
+                languages: ["[default]", "fr"],
+                accessToken: "preview-token",
+            },
+            {
+                spaceId: "space-1",
+                storyblokDeliveryApiUrl: "https://api.storyblok.com/v2",
+                rateLimit: 6,
+                sbApi: {} as any,
+            },
+        );
+
+        expect(storyblokClientConstructorMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                accessToken: "preview-token",
+                rateLimit: 6,
+                maxRetries: 10,
+                timeout: 60,
+                fetch: expect.any(Function),
+                cache: {
+                    clear: "auto",
+                    type: "none",
+                },
+            }),
+            "https://api.storyblok.com/v2",
+        );
+        expect(storyblokGetMock).toHaveBeenCalledWith(
+            "cdn/stories/translation-migration-testing/test-1/contact-us",
+            expect.objectContaining({
+                version: "published",
+                language: "fr",
+            }),
+        );
+        expect(storyblokGetMock).toHaveBeenCalledWith(
+            "cdn/stories/translation-migration-testing/test-1/contact-us",
+            expect.objectContaining({
+                version: "draft",
+                language: "fr",
+            }),
+        );
+        expect(result.stories?.[
+            "translation-migration-testing/test-1/contact-us"
+        ].languages?.fr?.state).toBe("published_clean");
+    });
+
+    it("keeps 404 as a valid draft-or-unpublished signal", async () => {
+        storyblokGetMock.mockImplementation((_path: string, params: any) => {
+            if (params.version === "published") {
+                return Promise.reject({
+                    status: 404,
+                    response: {
+                        status: 404,
+                        data: ["This record could not be found"],
+                    },
+                });
+            }
+
+            return Promise.resolve({
+                data: {
+                    story: {
+                        full_slug:
+                            "fr/translation-migration-testing/test-1/contact-us",
+                        published_at: null,
+                        content: {
+                            component: "page",
+                            body: [
+                                {
+                                    component: "target",
+                                    text: "Draft French",
+                                },
+                            ],
+                        },
+                    },
+                },
+            });
+        });
+
+        const result = await buildLanguagePublishStateMapFromStories(
+            {
+                from: "space-1",
+                stories: [createStoryItem()],
+                languages: ["fr"],
+                accessToken: "preview-token",
+            },
+            {
+                spaceId: "space-1",
+                storyblokDeliveryApiUrl: "https://api.storyblok.com/v2",
+                sbApi: {} as any,
+            },
+        );
+
+        expect(result.stories?.[
+            "translation-migration-testing/test-1/contact-us"
+        ].languages?.fr?.state).toBe("draft_or_unpublished");
+        expect(result.stories?.[
+            "translation-migration-testing/test-1/contact-us"
+        ].languages?.fr?.published).toMatchObject({
+            status: 404,
+            errorMessage: "This record could not be found",
+        });
+    });
+
+    it("maps Storyblok SDK not-found errors without status to draft-or-unpublished", async () => {
+        storyblokGetMock.mockImplementation((_path: string, params: any) => {
+            if (params.version === "published") {
+                return Promise.reject({
+                    message: "Not Found",
+                });
+            }
+
+            return Promise.resolve({
+                data: {
+                    story: {
+                        full_slug:
+                            "fr/translation-migration-testing/test-1/contact-us",
+                        published_at: null,
+                        content: {
+                            component: "page",
+                            body: [
+                                {
+                                    component: "target",
+                                    text: "Draft French",
+                                },
+                            ],
+                        },
+                    },
+                },
+            });
+        });
+
+        const result = await buildLanguagePublishStateMapFromStories(
+            {
+                from: "space-1",
+                stories: [createStoryItem()],
+                languages: ["fr"],
+                accessToken: "preview-token",
+            },
+            {
+                spaceId: "space-1",
+                storyblokDeliveryApiUrl: "https://api.storyblok.com/v2",
+                sbApi: {} as any,
+            },
+        );
+
+        expect(result.stories?.[
+            "translation-migration-testing/test-1/contact-us"
+        ].languages?.fr?.state).toBe("draft_or_unpublished");
+        expect(result.stories?.[
+            "translation-migration-testing/test-1/contact-us"
+        ].languages?.fr?.published).toMatchObject({
+            status: 404,
+            errorMessage: "Not Found",
+        });
+    });
+
+    it("does not accept a final 429 as a language publication state", async () => {
+        storyblokGetMock.mockRejectedValue({
+            status: 429,
+            response: { status: 429 },
+        });
+
+        await expect(
+            buildLanguagePublishStateMapFromStories(
+                {
+                    from: "space-1",
+                    stories: [createStoryItem()],
+                    languages: ["fr"],
+                    accessToken: "preview-token",
+                },
+                {
+                    spaceId: "space-1",
+                    storyblokDeliveryApiUrl: "https://api.storyblok.com/v2",
+                    sbApi: {} as any,
+                },
+            ),
+        ).rejects.toThrow(
+            "Storyblok Delivery API rate limit did not recover after retries",
+        );
+    });
+
+    it("does not write status 0 into the publish-state map", async () => {
+        storyblokGetMock.mockRejectedValue({
+            message: "Failed to parse Storyblok response",
+        });
+
+        await expect(
+            buildLanguagePublishStateMapFromStories(
+                {
+                    from: "space-1",
+                    stories: [createStoryItem()],
+                    languages: ["fr"],
+                    accessToken: "preview-token",
+                },
+                {
+                    spaceId: "space-1",
+                    storyblokDeliveryApiUrl: "https://api.storyblok.com/v2",
+                    sbApi: {} as any,
+                },
+            ),
+        ).rejects.toThrow(
+            "Storyblok Delivery API request failed without an HTTP status",
+        );
+    });
+
+    it("preserves HTTP status when Storyblok returns an empty error body", async () => {
+        const fetchWithEmptyErrorBody = vi.fn().mockResolvedValue(
+            new Response("", {
+                status: 404,
+                statusText: "Not Found",
+                headers: {
+                    "content-type": "text/plain",
+                },
+            }),
+        );
+        const safeFetch = createStatusPreservingFetch(
+            fetchWithEmptyErrorBody as unknown as typeof fetch,
+        );
+
+        const response = await safeFetch("https://api.storyblok.com/v2/test");
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({});
+    });
+
+    it("preserves HTTP status when Storyblok returns a non-json error body", async () => {
+        const fetchWithTextErrorBody = vi.fn().mockResolvedValue(
+            new Response("This record could not be found", {
+                status: 404,
+                statusText: "Not Found",
+                headers: {
+                    "content-type": "text/plain",
+                },
+            }),
+        );
+        const safeFetch = createStatusPreservingFetch(
+            fetchWithTextErrorBody as unknown as typeof fetch,
+        );
+
+        const response = await safeFetch("https://api.storyblok.com/v2/test");
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            error: "This record could not be found",
+        });
+    });
+});

--- a/__tests__/api/stories-update.test.ts
+++ b/__tests__/api/stories-update.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../src/utils/logger.js", () => ({
 }));
 
 import {
+    getStoryById,
     parsePublishLanguagesOption,
     resolvePublishLanguageCodes,
     resolveStoryPublishState,
@@ -131,6 +132,34 @@ describe("updateStory", () => {
             status: 422,
             response: "The field sb-tab-item.content can't be blank",
         });
+    });
+});
+
+describe("getStoryById", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("logs fetch errors with status and Storyblok response instead of object dumps", async () => {
+        const get = vi.fn().mockRejectedValue({
+            status: 429,
+            response: {
+                data: ["Too Many Requests"],
+            },
+        });
+        const config = {
+            spaceId: "291967263583956",
+            sbApi: {
+                get,
+            },
+        } as any;
+
+        const result = await getStoryById("story-1", config);
+
+        expect(result).toBeUndefined();
+        expect(loggerMock.error).toHaveBeenCalledWith(
+            "Failed to fetch story 'story-1' with full content from space '291967263583956' (status 429). Response: Too Many Requests",
+        );
     });
 });
 

--- a/src/api/stories/language-publish-state.ts
+++ b/src/api/stories/language-publish-state.ts
@@ -4,6 +4,8 @@ import { createHash } from "crypto";
 import fs from "fs";
 import path from "path";
 
+import StoryblokClient from "storyblok-js-client";
+
 import { mapWithConcurrency } from "../../utils/async-utils.js";
 import { createAndSaveToFile } from "../../utils/files.js";
 import Logger from "../../utils/logger.js";
@@ -12,6 +14,9 @@ import { getAllStories, getStoryBySlug } from "./stories.js";
 
 const DEFAULT_LANGUAGE = "[default]";
 const DELIVERY_CHECK_CONCURRENCY = 5;
+const DELIVERY_API_DEFAULT_RATE_LIMIT = 5;
+const DELIVERY_API_MAX_RETRIES = 10;
+const DELIVERY_API_TIMEOUT_SECONDS = 60;
 
 export type LanguagePublishState =
     | "published_clean"
@@ -75,7 +80,120 @@ interface DeliveryCheck {
     fullSlug: string | null;
     publishedAt: string | null;
     contentHash: string | null;
+    errorMessage?: string | null;
 }
+
+export const createStatusPreservingFetch =
+    (baseFetch: typeof fetch = fetch): typeof fetch =>
+    async (input, init) => {
+        const response = await baseFetch(input, init);
+
+        if (response.ok) {
+            return response;
+        }
+
+        const responseText = await response
+            .clone()
+            .text()
+            .catch(() => "");
+
+        if (responseText.trim().length === 0) {
+            return new Response("{}", {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+            });
+        }
+
+        try {
+            JSON.parse(responseText);
+            return response;
+        } catch {
+            return new Response(JSON.stringify({ error: responseText }), {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+            });
+        }
+    };
+
+const createDeliveryClient = ({
+    accessToken,
+    deliveryApiUrl,
+    rateLimit,
+}: {
+    accessToken: string;
+    deliveryApiUrl: string;
+    rateLimit?: number;
+}) =>
+    new StoryblokClient(
+        {
+            accessToken,
+            rateLimit: rateLimit ?? DELIVERY_API_DEFAULT_RATE_LIMIT,
+            maxRetries: DELIVERY_API_MAX_RETRIES,
+            timeout: DELIVERY_API_TIMEOUT_SECONDS,
+            fetch: createStatusPreservingFetch(),
+            cache: {
+                clear: "auto",
+                type: "none",
+            },
+        },
+        deliveryApiUrl,
+    );
+
+const resolveStoryblokErrorStatus = (error: any): number =>
+    error?.status ??
+    error?.response?.status ??
+    error?.response?.response?.status ??
+    error?.response?.data?.status ??
+    error?.message?.status ??
+    error?.message?.response?.status ??
+    error?.message?.response?.response?.status ??
+    error?.message?.response?.data?.status ??
+    0;
+
+const resolveStoryblokErrorMessage = (error: any): string | null => {
+    const responseData = error?.response?.data;
+
+    if (Array.isArray(responseData)) {
+        return responseData.filter(Boolean).join(", ") || null;
+    }
+
+    if (typeof responseData === "string") {
+        return responseData;
+    }
+
+    if (responseData && typeof responseData === "object") {
+        return (
+            responseData.error ||
+            responseData.message ||
+            error?.response?.message ||
+            error?.message?.message ||
+            error?.message ||
+            null
+        );
+    }
+
+    if (error?.message && typeof error.message === "object") {
+        return (
+            error.message.message ||
+            error.message.response?.message ||
+            error.message.response?.data?.error ||
+            null
+        );
+    }
+
+    return error?.message || null;
+};
+
+const isStoryblokNotFoundMessage = (message: string | null): boolean => {
+    const normalized = message?.trim().toLowerCase();
+
+    return (
+        normalized === "not found" ||
+        normalized === "this record could not be found"
+    );
+};
 
 const cleanStoryblokContent = (value: any): any => {
     if (Array.isArray(value)) {
@@ -203,40 +321,67 @@ const classifyTranslatedLanguageState = ({
 };
 
 const fetchDeliveryStory = async ({
-    deliveryApiUrl,
-    accessToken,
+    deliveryClient,
     slug,
     version,
     language,
 }: {
-    deliveryApiUrl: string;
-    accessToken: string;
+    deliveryClient: Pick<StoryblokClient, "get">;
     slug: string;
     version: "published" | "draft";
     language?: string;
 }): Promise<DeliveryCheck> => {
-    const url = new URL(
-        `${deliveryApiUrl.replace(/\/$/, "")}/cdn/stories/${slug}`,
-    );
-    url.searchParams.set("token", accessToken);
-    url.searchParams.set("version", version);
-    url.searchParams.set("cv", String(Date.now()));
+    const params: Record<string, string> = {
+        version,
+        cv: String(Date.now()),
+    };
 
     if (language && language !== DEFAULT_LANGUAGE) {
-        url.searchParams.set("language", language);
+        params.language = language;
     }
 
-    const response = await fetch(url);
-    const data = await response.json().catch(() => null);
-    const story = data?.story;
+    try {
+        const response = await deliveryClient.get(
+            `cdn/stories/${slug}`,
+            params,
+        );
+        const story = response?.data?.story;
 
-    return {
-        status: response.status,
-        ok: response.ok,
-        fullSlug: story?.full_slug || null,
-        publishedAt: story?.published_at || null,
-        contentHash: story?.content ? hashContent(story.content) : null,
-    };
+        return {
+            status: 200,
+            ok: true,
+            fullSlug: story?.full_slug || null,
+            publishedAt: story?.published_at || null,
+            contentHash: story?.content ? hashContent(story.content) : null,
+        };
+    } catch (error: any) {
+        const errorMessage = resolveStoryblokErrorMessage(error);
+        const status =
+            resolveStoryblokErrorStatus(error) ||
+            (isStoryblokNotFoundMessage(errorMessage) ? 404 : 0);
+        const story = error?.response?.data?.story;
+
+        if (status === 429) {
+            throw new Error(
+                `Storyblok Delivery API rate limit did not recover after retries for '${slug}' (${version}${language ? `, ${language}` : ""}).`,
+            );
+        }
+
+        if (status === 0) {
+            throw new Error(
+                `Storyblok Delivery API request failed without an HTTP status for '${slug}' (${version}${language ? `, ${language}` : ""})${errorMessage ? `: ${errorMessage}` : "."}`,
+            );
+        }
+
+        return {
+            status,
+            ok: false,
+            fullSlug: story?.full_slug || null,
+            publishedAt: story?.published_at || null,
+            contentHash: story?.content ? hashContent(story.content) : null,
+            errorMessage,
+        };
+    }
 };
 
 const loadStoriesForLanguageState = async (
@@ -384,13 +529,31 @@ export const buildLanguagePublishStateMapFromStories = async (
     }
 
     const deliveryAccessToken = accessToken || "";
-
     const deliveryApiUrl =
         config.storyblokDeliveryApiUrl || "https://api.storyblok.com/v2";
     const uniqueLanguages = Array.from(new Set(args.languages));
+    const translatedLanguages = uniqueLanguages.filter(
+        (language) => language !== DEFAULT_LANGUAGE,
+    );
     const stories = args.stories.filter(
         (item: any) => item?.story && item.story.is_folder !== true,
     );
+    const deliveryClient = needsDeliveryApi
+        ? createDeliveryClient({
+              accessToken: deliveryAccessToken,
+              deliveryApiUrl,
+              rateLimit: config.rateLimit,
+          })
+        : null;
+    const totalDeliveryChecks = stories.length * translatedLanguages.length * 2;
+
+    if (needsDeliveryApi) {
+        Logger.log(
+            `Resolving translated language publish state for ${stories.length} stories and ${translatedLanguages.length} language(s). Up to ${totalDeliveryChecks} Delivery API check(s) will run through StoryblokClient at ${config.rateLimit ?? DELIVERY_API_DEFAULT_RATE_LIMIT} req/s.`,
+        );
+    }
+
+    let processedStories = 0;
 
     const storyEntries = await mapWithConcurrency(
         stories,
@@ -414,15 +577,13 @@ export const buildLanguagePublishStateMapFromStories = async (
 
                 const [published, draft] = await Promise.all([
                     fetchDeliveryStory({
-                        deliveryApiUrl,
-                        accessToken: deliveryAccessToken,
+                        deliveryClient: deliveryClient as StoryblokClient,
                         slug: story.full_slug,
                         version: "published",
                         language,
                     }),
                     fetchDeliveryStory({
-                        deliveryApiUrl,
-                        accessToken: deliveryAccessToken,
+                        deliveryClient: deliveryClient as StoryblokClient,
                         slug: story.full_slug,
                         version: "draft",
                         language,
@@ -440,7 +601,7 @@ export const buildLanguagePublishStateMapFromStories = async (
                 };
             }
 
-            return {
+            const storyEntry = {
                 id: story.id,
                 uuid: story.uuid,
                 name: story.name,
@@ -452,6 +613,19 @@ export const buildLanguagePublishStateMapFromStories = async (
                     )
                     .map(([language]) => language),
             };
+
+            processedStories++;
+            if (
+                needsDeliveryApi &&
+                (processedStories % 10 === 0 ||
+                    processedStories === stories.length)
+            ) {
+                Logger.success(
+                    `Resolved translated language publish state for ${processedStories}/${stories.length} stories.`,
+                );
+            }
+
+            return storyEntry;
         },
     );
 

--- a/src/api/stories/stories.ts
+++ b/src/api/stories/stories.ts
@@ -327,9 +327,24 @@ const subtractLanguages = (
 const formatLanguageList = (languages: string[] | undefined): string =>
     languages && languages.length > 0 ? languages.join(",") : "none";
 
+const resolveStoryblokErrorStatus = (err: any): number | undefined =>
+    err?.status ??
+    err?.response?.status ??
+    err?.response?.response?.status ??
+    err?.message?.status ??
+    err?.message?.response?.status;
+
 const resolveStoryblokErrorResponse = (err: any): string | undefined => {
     if (typeof err?.response === "string" && err.response.trim().length > 0) {
         return err.response.trim();
+    }
+
+    if (Array.isArray(err?.response?.data)) {
+        const message = err.response.data.filter(Boolean).join(", ").trim();
+
+        if (message.length > 0) {
+            return message;
+        }
     }
 
     if (
@@ -344,6 +359,31 @@ const resolveStoryblokErrorResponse = (err: any): string | undefined => {
         err.response.message.trim().length > 0
     ) {
         return err.response.message.trim();
+    }
+
+    if (
+        typeof err?.message?.message === "string" &&
+        err.message.message.trim().length > 0
+    ) {
+        return err.message.message.trim();
+    }
+
+    if (Array.isArray(err?.message?.response?.data)) {
+        const message = err.message.response.data
+            .filter(Boolean)
+            .join(", ")
+            .trim();
+
+        if (message.length > 0) {
+            return message;
+        }
+    }
+
+    if (
+        typeof err?.message?.response?.data === "string" &&
+        err.message.response.data.trim().length > 0
+    ) {
+        return err.message.response.data.trim();
     }
 
     if (typeof err?.message === "string" && err.message.trim().length > 0) {
@@ -468,7 +508,20 @@ export const getStoryById: GetStoryById = (storyId, config) => {
 
             return res.data;
         })
-        .catch((err: any) => Logger.error(err));
+        .catch((err: any) => {
+            const status = resolveStoryblokErrorStatus(err);
+            const responseMessage = resolveStoryblokErrorResponse(err);
+            const statusLabel = status ? `status ${status}` : "unknown status";
+            const responseLabel = responseMessage
+                ? ` Response: ${responseMessage}`
+                : "";
+
+            Logger.error(
+                `Failed to fetch story '${storyId}' with full content from space '${spaceId}' (${statusLabel}).${responseLabel}`,
+            );
+
+            return undefined;
+        });
 };
 
 export const getStoryBySlug: GetStoryBySlug = async (slug, config) => {


### PR DESCRIPTION
## Summary
- replace raw Delivery API fetches in language publish-state checks with StoryblokClient
- configure the Delivery client with rate limiting and SDK retry support
- reject unrecovered 429 responses instead of turning them into normal language states
- add focused unit coverage for SDK usage, 404 handling, and final 429 failure

## Validation
- npm run typecheck
- npm run lint
- npm run test:unit -- __tests__/api/language-publish-state.test.ts
- npm run build