### PR TITLE
feat(inspect): add component usage queries

### DIFF
--- a/__tests__/api/component-usage-inspect.test.ts
+++ b/__tests__/api/component-usage-inspect.test.ts
@@ -1,0 +1,161 @@
+import type { ComponentUsageQuery } from "../../src/api/inspect/component-usage.types.js";
+
+import path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { loadComponentUsageQueryFromPath } from "../../src/api/inspect/component-usage-query.js";
+import {
+    inspectFetchedStories,
+    inspectStoryContent,
+} from "../../src/api/inspect/component-usage.js";
+
+const story = {
+    id: 100,
+    name: "Home",
+    slug: "home",
+    full_slug: "home",
+    is_folder: false,
+    content: {
+        _uid: "root",
+        component: "page",
+        body: [
+            {
+                _uid: "flex-1",
+                component: "flex-group",
+                direction: "vertical",
+                body: [
+                    {
+                        _uid: "child-1",
+                        component: "teaser",
+                        width: "1/2",
+                    },
+                    {
+                        _uid: "child-2",
+                        component: "teaser",
+                        width: "",
+                    },
+                ],
+            },
+            {
+                _uid: "flex-2",
+                component: "flex-group",
+                direction: "horizontal",
+                body: [
+                    {
+                        _uid: "child-3",
+                        component: "teaser",
+                        width: "1/3",
+                    },
+                ],
+            },
+        ],
+    },
+};
+
+describe("component usage inspection", () => {
+    it("walks nested Storyblok components and reports matcher details", async () => {
+        const query: ComponentUsageQuery = {
+            name: "flex-group-width-child",
+            match(node) {
+                if (node.component !== "flex-group") {
+                    return null;
+                }
+
+                const children = Array.isArray(node.body) ? node.body : [];
+                const childrenWithWidth = children.filter(
+                    (child) => child.width,
+                );
+
+                if (
+                    node.direction !== "vertical" ||
+                    childrenWithWidth.length === 0
+                ) {
+                    return null;
+                }
+
+                return {
+                    childMatches: childrenWithWidth.length,
+                };
+            },
+        };
+
+        const matches = await inspectStoryContent({ story, query });
+
+        expect(matches).toEqual([
+            {
+                storyId: 100,
+                storyName: "Home",
+                storySlug: "home",
+                storyFullSlug: "home",
+                component: "flex-group",
+                uid: "flex-1",
+                path: "content.body[0]",
+                parentComponent: "page",
+                parentUid: "root",
+                details: {
+                    childMatches: 1,
+                },
+            },
+        ]);
+    });
+
+    it("builds report totals and skips folders", async () => {
+        const query: ComponentUsageQuery = {
+            name: "all-flex",
+            match(node) {
+                return node.component === "flex-group";
+            },
+        };
+
+        const report = await inspectFetchedStories({
+            stories: [
+                { story },
+                {
+                    story: {
+                        id: 200,
+                        name: "Folder",
+                        slug: "folder",
+                        full_slug: "folder",
+                        is_folder: true,
+                        content: {
+                            component: "folder",
+                        },
+                    },
+                },
+            ],
+            query,
+            spaceId: "12345",
+            filters: { all: true },
+        });
+
+        expect(report.queryName).toBe("all-flex");
+        expect(report.spaceId).toBe("12345");
+        expect(report.filters).toEqual({ all: true });
+        expect(report.totals).toEqual({
+            storiesScanned: 1,
+            storiesMatched: 1,
+            matches: 2,
+        });
+        expect(report.matches.map((match) => match.uid)).toEqual([
+            "flex-1",
+            "flex-2",
+        ]);
+    });
+
+    it("loads a JS query file and applies the ticket query behavior", async () => {
+        const queryPath = path.resolve(
+            process.cwd(),
+            "__tests__/fixtures/queries/flex-group-width-child.sb.query.js",
+        );
+        const query = await loadComponentUsageQueryFromPath(queryPath);
+        const matches = await inspectStoryContent({ story, query });
+
+        expect(query.name).toBe("flex-group-width-child");
+        expect(matches).toHaveLength(1);
+        expect(matches[0]?.details).toEqual({
+            childMatches: 1,
+            matchingChildUids: ["child-1"],
+        });
+    });
+});

--- a/__tests__/fixtures/queries/flex-group-width-child.sb.query.js
+++ b/__tests__/fixtures/queries/flex-group-width-child.sb.query.js
@@ -1,0 +1,37 @@
+const hasValue = (value) =>
+    value !== undefined && value !== null && value !== "";
+
+const directArrayChildren = (node) =>
+    Object.values(node)
+        .filter(Array.isArray)
+        .flat()
+        .filter((item) => item && typeof item === "object" && item.component);
+
+export default {
+    name: "flex-group-width-child",
+    description:
+        "Find flex groups with vertical or reverse direction and children with width.",
+
+    match(node) {
+        if (node.component !== "flex-group") {
+            return null;
+        }
+
+        if (!["vertical", "reverse"].includes(node.direction)) {
+            return null;
+        }
+
+        const childrenWithWidth = directArrayChildren(node).filter((child) =>
+            hasValue(child.width),
+        );
+
+        if (childrenWithWidth.length === 0) {
+            return null;
+        }
+
+        return {
+            childMatches: childrenWithWidth.length,
+            matchingChildUids: childrenWithWidth.map((child) => child._uid),
+        };
+    },
+};

--- a/docs/gctt-3770-component-usage-inspect.md
+++ b/docs/gctt-3770-component-usage-inspect.md
@@ -1,0 +1,482 @@
+# GCTT-3770 Component usage inspection
+
+## Ticket summary
+
+Jira: `GCTT-3770`
+
+Title: `Sb-Mig: Add functionality to find usage of component combinations`
+
+Goal: add a read-only sb-mig capability that can inspect Storyblok stories and report where specific component combinations are used.
+
+The first real investigation is:
+
+> Find and count stories where a vertical or reverse-direction flex group has at least one child with a width setting.
+
+The implementation should not be hard-coded only for flex groups. It should create a reusable traversal engine so future investigations can be expressed as small queries.
+
+## Product shape
+
+Add a read-only inspect command:
+
+```bash
+sb-mig inspect component-usage --from 12345 --query flex-group-width-child
+```
+
+The query file is the only matcher interface for the first implementation. Do not add a second flag-based query language.
+
+## Core design
+
+Split the feature into two layers.
+
+### 1. Traversal engine
+
+The traversal engine is internal reusable code. It:
+
+- fetches selected stories from a Storyblok space
+- skips folders by default
+- walks every nested Storyblok blok/component in `story.content`
+- tracks where each component is found
+- passes each component node to a matcher/query
+- collects matches into a structured report
+
+The scanner should be read-only. It must not call story update, publish, delete, or create endpoints.
+
+### 2. Matchers
+
+A matcher describes what we are looking for.
+
+There is one matcher source:
+
+- query files, for expressive reusable project-specific checks
+
+The engine should receive a normalized matcher function created from a query file.
+
+## Query files
+
+Query files are the advanced and preferred long-term interface.
+
+Proposed naming convention:
+
+```txt
+*.sb.query.ts
+*.sb.query.js
+*.sb.query.cjs
+*.sb.query.mjs
+```
+
+Example:
+
+```txt
+flex-group-width-child.sb.query.ts
+```
+
+Usage:
+
+```bash
+sb-mig inspect component-usage --from 12345 --query flex-group-width-child
+```
+
+The query discovery behavior should follow existing sb-mig conventions where possible:
+
+- resolve by query name first
+- look in configured component/search directories where practical
+- allow direct file path later if needed
+- support TS through the existing on-the-fly build path if practical
+
+### Query file contract
+
+A query file exports a default query object:
+
+```ts
+export default {
+  name: "flex-group-width-child",
+  description:
+    "Find flex groups with vertical or reverse direction and children with width.",
+
+  match(node, context) {
+    if (node.component !== "flex-group") {
+      return null;
+    }
+
+    if (!["vertical", "reverse"].includes(node.direction)) {
+      return null;
+    }
+
+    const children = Array.isArray(node.body) ? node.body : [];
+    const childrenWithWidth = children.filter((child) => {
+      return child.width !== undefined && child.width !== null && child.width !== "";
+    });
+
+    if (childrenWithWidth.length === 0) {
+      return null;
+    }
+
+    return {
+      childMatches: childrenWithWidth.length,
+      matchingChildUids: childrenWithWidth.map((child) => child._uid),
+    };
+  },
+};
+```
+
+The scanner calls `match(node, context)` for every component node it visits.
+
+Return values:
+
+- `null` or `undefined`: no match
+- object: a match; object is stored under `details` in the report
+- `true`: a match with no extra details
+
+### Query context
+
+The matcher receives:
+
+```ts
+interface ComponentUsageQueryContext {
+  story: {
+    id: number | string;
+    name?: string;
+    slug?: string;
+    full_slug?: string;
+  };
+  path: string;
+  parent?: Record<string, unknown>;
+  ancestors: Array<Record<string, unknown>>;
+}
+```
+
+The initial implementation only needs `story`, `path`, `parent`, and `ancestors`. Do not over-design the API before real queries need more.
+
+### Query result normalization
+
+Each match should become:
+
+```ts
+interface ComponentUsageMatch {
+  storyId: number | string;
+  storyName?: string;
+  storySlug?: string;
+  storyFullSlug?: string;
+  component: string;
+  uid?: string;
+  path: string;
+  parentComponent?: string;
+  parentUid?: string;
+  details?: Record<string, unknown>;
+}
+```
+
+## Query-only parent and child example
+
+Do not implement a CLI flag matcher in the first version.
+
+The earlier flag-based idea:
+
+```bash
+sb-mig inspect component-usage \
+  --from 12345 \
+  --parentComponent flex-group \
+  --parentField direction=vertical,reverse \
+  --childHasField width
+```
+
+should instead be represented as a query file:
+
+```ts
+const hasValue = (value: unknown): boolean =>
+  value !== undefined && value !== null && value !== "";
+
+const directArrayChildren = (node: Record<string, any>): Record<string, any>[] =>
+  Object.values(node)
+    .filter(Array.isArray)
+    .flat()
+    .filter((item) => item && typeof item === "object" && item.component);
+
+export default {
+  name: "flex-group-width-child",
+  description:
+    "Find flex groups with vertical or reverse direction and children with width.",
+
+  match(node) {
+    if (node.component !== "flex-group") {
+      return null;
+    }
+
+    if (!["vertical", "reverse"].includes(node.direction)) {
+      return null;
+    }
+
+    const childrenWithWidth = directArrayChildren(node).filter((child) =>
+      hasValue(child.width),
+    );
+
+    if (childrenWithWidth.length === 0) {
+      return null;
+    }
+
+    return {
+      childMatches: childrenWithWidth.length,
+      matchingChildUids: childrenWithWidth.map((child) => child._uid),
+    };
+  },
+};
+```
+
+This keeps the feature simple: one command path, one matcher contract, one way to express inspection logic.
+
+## Story selection
+
+Initial selection flags:
+
+```txt
+--from <spaceId>
+--all
+--withSlug <full_slug> repeatable
+--startsWith <prefix>
+```
+
+Behavior:
+
+- `--from` is required unless the configured `spaceId` fallback is intentionally reused.
+- `--all`, `--withSlug`, or `--startsWith` selects stories.
+- If no selector is passed, default to all non-folder stories only if that matches existing sb-mig command style. Otherwise require `--all`.
+- Skip folders in matching, but folders may be fetched as part of Storyblok listing.
+
+## Output
+
+Console output should be concise and useful:
+
+```txt
+Component usage inspection
+Space: 12345
+Query: flex-group-width-child
+Stories scanned: 1240
+Stories matched: 37
+Total matches: 52
+
+Matches by story:
+- home: 2
+- campaign/summer: 1
+- ...
+```
+
+JSON output should be available:
+
+```bash
+sb-mig inspect component-usage \
+  --from 12345 \
+  --query flex-group-width-child \
+  --outputPath sbmig/usage/flex-group-width-child.json
+```
+
+Report shape:
+
+```ts
+interface ComponentUsageReport {
+  queryName: string;
+  spaceId: string;
+  generatedAt: string;
+  filters: {
+    all?: boolean;
+    withSlug?: string[];
+    startsWith?: string;
+  };
+  totals: {
+    storiesScanned: number;
+    storiesMatched: number;
+    matches: number;
+  };
+  matches: ComponentUsageMatch[];
+}
+```
+
+## Proposed file locations
+
+Implementation:
+
+```txt
+src/api/inspect/component-usage.ts
+src/api/inspect/component-usage.types.ts
+src/api/inspect/component-usage-query.ts
+src/api/inspect/index.ts
+src/cli/commands/inspect.ts
+```
+
+Tests:
+
+```txt
+__tests__/api/component-usage-inspect.test.ts
+__tests__/cli/inspect-component-usage.test.ts
+__tests__/fixtures/queries/flex-group-width-child.sb.query.js
+```
+
+Docs:
+
+```txt
+docs/gctt-3770-component-usage-inspect.md
+```
+
+## Implementation phases
+
+### Phase 0: Spec and decisions
+
+Status: planned
+
+Tasks:
+
+- capture ticket context
+- agree command name
+- agree query file contract
+- agree that query files are the only matcher interface for the first implementation
+- keep feature read-only
+
+Exit criteria:
+
+- this spec exists and is accepted as the working plan
+
+### Phase 1: Pure traversal engine
+
+Status: planned
+
+Tasks:
+
+- implement a pure recursive walker for Storyblok content
+- pass each component node to a matcher
+- track `path`, `parent`, and `ancestors`
+- return normalized matches
+- add unit tests with fixture story content
+
+No Storyblok API calls in this phase.
+
+Exit criteria:
+
+- tests prove nested components are found
+- tests prove parent and ancestor context is correct
+- tests prove matcher result normalization
+
+### Phase 2: Story scanning API
+
+Status: planned
+
+Tasks:
+
+- add API function that accepts fetched stories and a matcher
+- optionally add API function that fetches selected stories using existing `getAllStories`
+- skip folders by default
+- compute report totals
+- add tests for story-level aggregation
+
+Exit criteria:
+
+- report contains story counts, match counts, and match rows
+- no write endpoints are used
+
+### Phase 3: Query file loading
+
+Status: planned
+
+Tasks:
+
+- discover/load `*.sb.query.*` files
+- normalize default export into matcher
+- validate query shape and error clearly
+- support JS first
+- support TS using existing build-on-the-fly path if it is low risk
+
+Exit criteria:
+
+- a fixture query file can be loaded by name
+- invalid query files fail with actionable errors
+
+### Phase 4: CLI command
+
+Status: planned
+
+Tasks:
+
+- add `inspect` command to `src/cli/index.ts`
+- add `inspect component-usage` subcommand
+- add flags:
+  - `--from`
+  - `--all`
+  - `--withSlug`
+  - `--startsWith`
+  - `--query`
+  - `--outputPath`
+- print summary to console
+- write JSON when `--outputPath` is passed
+
+Exit criteria:
+
+- CLI can run query-file mode
+- CLI rejects missing `--query` clearly
+
+### Phase 5: Built-in first query/example
+
+Status: planned
+
+Tasks:
+
+- include an example query for the ticket case
+- document it in README or command help
+- decide whether built-in queries live in source or docs/examples
+
+Candidate query:
+
+```txt
+flex-group-width-child
+```
+
+Exit criteria:
+
+- the original Jira investigation can be run without writing custom code from scratch
+
+### Phase 6: Hardening and follow-ups
+
+Status: planned
+
+Possible improvements:
+
+- support direct query file path
+- support multiple queries in one run
+- support CSV output
+- support `--includeFolders`
+- expose API through `src/api-v2`
+- add richer progress reporting for large spaces
+
+These should not block the first ticket implementation.
+
+## Testing strategy
+
+Unit tests should cover:
+
+- recursive content traversal
+- arrays and nested objects
+- parent context
+- ancestor context
+- path generation
+- matcher return types: `null`, `undefined`, `true`, object
+- query file validation
+- report totals
+
+CLI tests should cover:
+
+- query-file mode
+- missing required selector or missing matcher
+- JSON output path
+
+Live API tests are not required for the first implementation.
+
+## Open decisions
+
+- Should no selector default to `--all`, or should the user be forced to pass `--all` for safety?
+- Should the query extension be exactly `.sb.query.ts`, or should JS/CJS/MJS be supported from day one?
+- Should the first query be bundled as a built-in query or documented as an example file?
+- Should the command name be `inspect component-usage`, `usage components`, or `discover usage`?
+
+Current recommendation:
+
+- require explicit `--all`, `--withSlug`, or `--startsWith`
+- support JS query files first and TS if it reuses existing infrastructure cleanly
+- expose the flex-group query as an example first, then promote to built-in if it proves generally useful
+- use `inspect component-usage` because the command is read-only and investigative

--- a/src/api/inspect/component-usage-query.ts
+++ b/src/api/inspect/component-usage-query.ts
@@ -1,0 +1,123 @@
+import type { ComponentUsageQuery } from "./component-usage.types.js";
+
+import path from "path";
+
+import storyblokConfig from "../../config/config.js";
+import { toImportSpecifier } from "../../utils/files.js";
+import { safeGlobSync as globSync } from "../../utils/glob-utils.js";
+import { normalizeDiscover } from "../../utils/path-utils.js";
+
+const QUERY_EXTENSIONS = [
+    "sb.query.js",
+    "sb.query.cjs",
+    "sb.query.mjs",
+] as const;
+
+const isDirectQueryPath = (queryNameOrPath: string): boolean =>
+    queryNameOrPath.includes("/") ||
+    queryNameOrPath.includes("\\") ||
+    QUERY_EXTENSIONS.some((ext) => queryNameOrPath.endsWith(`.${ext}`));
+
+const withoutKnownQueryExtension = (queryName: string): string => {
+    for (const ext of QUERY_EXTENSIONS) {
+        const suffix = `.${ext}`;
+        if (queryName.endsWith(suffix)) {
+            return queryName.slice(0, -suffix.length);
+        }
+    }
+
+    return queryName;
+};
+
+const querySearchDirectories = (): string[] =>
+    storyblokConfig.componentsDirectories.filter(
+        (directory: string) => !directory.includes("node_modules"),
+    );
+
+export const discoverComponentUsageQueryFiles = (
+    queryName: string,
+): string[] => {
+    const rootDirectory = path.resolve(process.cwd(), "./");
+    const searchDirectories = querySearchDirectories();
+    const normalizedQueryName = withoutKnownQueryExtension(queryName);
+
+    return QUERY_EXTENSIONS.flatMap((ext) => {
+        const pattern = path.join(
+            rootDirectory,
+            normalizeDiscover({ segments: searchDirectories }),
+            "**",
+            `${normalizedQueryName}.${ext}`,
+        );
+
+        return globSync(pattern.replace(/\\/g, "/"), {
+            follow: true,
+        });
+    });
+};
+
+function assertValidQuery(
+    query: unknown,
+    sourcePath: string,
+): asserts query is ComponentUsageQuery {
+    if (!query || typeof query !== "object") {
+        throw new Error(`Query file '${sourcePath}' must export an object.`);
+    }
+
+    const candidate = query as Partial<ComponentUsageQuery>;
+
+    if (typeof candidate.name !== "string" || candidate.name.length === 0) {
+        throw new Error(
+            `Query file '${sourcePath}' must export a non-empty 'name'.`,
+        );
+    }
+
+    if (typeof candidate.match !== "function") {
+        throw new Error(
+            `Query file '${sourcePath}' must export a 'match' function.`,
+        );
+    }
+}
+
+export const loadComponentUsageQueryFromPath = async (
+    queryPath: string,
+): Promise<ComponentUsageQuery> => {
+    const resolvedPath = path.isAbsolute(queryPath)
+        ? queryPath
+        : path.resolve(process.cwd(), queryPath);
+    const module = await import(
+        /* @vite-ignore */ toImportSpecifier(resolvedPath)
+    );
+    const query = module.default || module;
+
+    assertValidQuery(query, resolvedPath);
+
+    return query;
+};
+
+export const loadComponentUsageQuery = async (
+    queryNameOrPath: string,
+): Promise<ComponentUsageQuery> => {
+    if (!queryNameOrPath || queryNameOrPath.trim().length === 0) {
+        throw new Error("--query is required for inspect component-usage.");
+    }
+
+    if (isDirectQueryPath(queryNameOrPath)) {
+        return loadComponentUsageQueryFromPath(queryNameOrPath);
+    }
+
+    const discoveredFiles = discoverComponentUsageQueryFiles(queryNameOrPath);
+
+    if (discoveredFiles.length === 0) {
+        throw new Error(
+            `No component usage query found for '${queryNameOrPath}'. Expected a file named '${queryNameOrPath}.sb.query.js', '${queryNameOrPath}.sb.query.cjs', or '${queryNameOrPath}.sb.query.mjs' in configured component directories.`,
+        );
+    }
+
+    if (discoveredFiles.length > 1) {
+        throw new Error(
+            `Multiple component usage queries found for '${queryNameOrPath}': ${discoveredFiles.join(", ")}`,
+        );
+    }
+
+    return loadComponentUsageQueryFromPath(discoveredFiles[0] as string);
+};

--- a/src/api/inspect/component-usage.ts
+++ b/src/api/inspect/component-usage.ts
@@ -1,0 +1,264 @@
+import type {
+    ComponentUsageFilters,
+    ComponentUsageMatch,
+    ComponentUsageQuery,
+    ComponentUsageQueryContext,
+    ComponentUsageQueryMatchResult,
+    ComponentUsageReport,
+    ComponentUsageStoryRef,
+    InspectFetchedStoriesArgs,
+    InspectStoryblokStoriesArgs,
+} from "./component-usage.types.js";
+import type { RequestBaseConfig } from "../utils/request.js";
+
+import { getAllStories, getStoryBySlug } from "../stories/stories.js";
+
+const isRecord = (value: unknown): value is Record<string, any> =>
+    Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const isComponentNode = (value: unknown): value is Record<string, any> =>
+    isRecord(value) && typeof value.component === "string";
+
+const normalizeStory = (storyData: any): ComponentUsageStoryRef => {
+    const story = storyData?.story || storyData || {};
+
+    return story;
+};
+
+const storyHasContent = (story: ComponentUsageStoryRef): boolean =>
+    isRecord(story.content);
+
+const normalizeMatchDetails = (
+    matchResult: ComponentUsageQueryMatchResult,
+): Record<string, unknown> | undefined => {
+    if (matchResult === true) {
+        return undefined;
+    }
+
+    if (isRecord(matchResult)) {
+        return matchResult;
+    }
+
+    return undefined;
+};
+
+const createMatch = ({
+    node,
+    context,
+    matchResult,
+}: {
+    node: Record<string, any>;
+    context: ComponentUsageQueryContext;
+    matchResult: ComponentUsageQueryMatchResult;
+}): ComponentUsageMatch => {
+    const details = normalizeMatchDetails(matchResult);
+    const match: ComponentUsageMatch = {
+        storyId: context.story.id,
+        storyName: context.story.name,
+        storySlug: context.story.slug,
+        storyFullSlug: context.story.full_slug,
+        component: node.component,
+        uid: typeof node._uid === "string" ? node._uid : undefined,
+        path: context.path,
+        parentComponent:
+            typeof context.parent?.component === "string"
+                ? context.parent.component
+                : undefined,
+        parentUid:
+            typeof context.parent?._uid === "string"
+                ? context.parent._uid
+                : undefined,
+    };
+
+    if (details) {
+        match.details = details;
+    }
+
+    return match;
+};
+
+const joinPath = (path: string, segment: string): string =>
+    path.length > 0 ? `${path}.${segment}` : segment;
+
+const walkValue = async ({
+    value,
+    path,
+    story,
+    parent,
+    ancestors,
+    query,
+    matches,
+}: {
+    value: unknown;
+    path: string;
+    story: ComponentUsageStoryRef;
+    parent?: Record<string, unknown>;
+    ancestors: Array<Record<string, unknown>>;
+    query: ComponentUsageQuery;
+    matches: ComponentUsageMatch[];
+}): Promise<void> => {
+    if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+            await walkValue({
+                value: value[i],
+                path: `${path}[${i}]`,
+                story,
+                parent,
+                ancestors,
+                query,
+                matches,
+            });
+        }
+
+        return;
+    }
+
+    if (!isRecord(value)) {
+        return;
+    }
+
+    const currentParent = isComponentNode(value) ? value : parent;
+    const currentAncestors = isComponentNode(value)
+        ? [...ancestors, value]
+        : ancestors;
+
+    if (isComponentNode(value)) {
+        const context: ComponentUsageQueryContext = {
+            story,
+            path,
+            parent,
+            ancestors,
+        };
+        const matchResult = await query.match(value, context);
+
+        if (matchResult) {
+            matches.push(
+                createMatch({
+                    node: value,
+                    context,
+                    matchResult,
+                }),
+            );
+        }
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+        if (key === "_uid" || key === "component") {
+            continue;
+        }
+
+        await walkValue({
+            value: child,
+            path: joinPath(path, key),
+            story,
+            parent: currentParent,
+            ancestors: currentAncestors,
+            query,
+            matches,
+        });
+    }
+};
+
+export const inspectStoryContent = async ({
+    story,
+    query,
+}: {
+    story: ComponentUsageStoryRef;
+    query: ComponentUsageQuery;
+}): Promise<ComponentUsageMatch[]> => {
+    const matches: ComponentUsageMatch[] = [];
+
+    if (!storyHasContent(story)) {
+        return matches;
+    }
+
+    await walkValue({
+        value: story.content,
+        path: "content",
+        story,
+        query,
+        matches,
+        ancestors: [],
+    });
+
+    return matches;
+};
+
+export const inspectFetchedStories = async ({
+    stories,
+    query,
+    spaceId,
+    filters = {},
+}: InspectFetchedStoriesArgs): Promise<ComponentUsageReport> => {
+    const selectedStories = stories
+        .map(normalizeStory)
+        .filter((story) => !story.is_folder);
+    const matchesByStory = await Promise.all(
+        selectedStories.map(async (story) =>
+            inspectStoryContent({ story, query }),
+        ),
+    );
+    const matches = matchesByStory.flat();
+    const matchedStoryIds = new Set(matches.map((match) => match.storyId));
+
+    return {
+        queryName: query.name,
+        spaceId,
+        generatedAt: new Date().toISOString(),
+        filters,
+        totals: {
+            storiesScanned: selectedStories.length,
+            storiesMatched: matchedStoryIds.size,
+            matches: matches.length,
+        },
+        matches,
+    };
+};
+
+const resolveStoryFetchOptions = (filters: ComponentUsageFilters) => {
+    if (filters.startsWith) {
+        return { starts_with: filters.startsWith };
+    }
+
+    return {};
+};
+
+export const inspectStoryblokStories = async (
+    args: InspectStoryblokStoriesArgs,
+    config: RequestBaseConfig,
+): Promise<ComponentUsageReport> => {
+    const { query, spaceId, filters } = args;
+
+    if (filters.withSlug && filters.withSlug.length > 0) {
+        const stories = await Promise.all(
+            filters.withSlug.map((slug) =>
+                getStoryBySlug(slug, {
+                    ...config,
+                    spaceId,
+                }),
+            ),
+        );
+
+        return inspectFetchedStories({
+            stories: stories.filter(Boolean),
+            query,
+            spaceId,
+            filters,
+        });
+    }
+
+    const stories = await getAllStories(
+        { options: resolveStoryFetchOptions(filters) },
+        {
+            ...config,
+            spaceId,
+        },
+    );
+
+    return inspectFetchedStories({
+        stories,
+        query,
+        spaceId,
+        filters,
+    });
+};

--- a/src/api/inspect/component-usage.types.ts
+++ b/src/api/inspect/component-usage.types.ts
@@ -1,0 +1,78 @@
+export interface ComponentUsageStoryRef {
+    id: number | string;
+    name?: string;
+    slug?: string;
+    full_slug?: string;
+    is_folder?: boolean;
+    content?: Record<string, unknown>;
+}
+
+export interface ComponentUsageQueryContext {
+    story: ComponentUsageStoryRef;
+    path: string;
+    parent?: Record<string, unknown>;
+    ancestors: Array<Record<string, unknown>>;
+}
+
+export type ComponentUsageQueryMatchResult =
+    | boolean
+    | Record<string, unknown>
+    | null
+    | undefined;
+
+export interface ComponentUsageQuery {
+    name: string;
+    description?: string;
+    match: (
+        node: Record<string, any>,
+        context: ComponentUsageQueryContext,
+    ) =>
+        | ComponentUsageQueryMatchResult
+        | Promise<ComponentUsageQueryMatchResult>;
+}
+
+export interface ComponentUsageMatch {
+    storyId: number | string;
+    storyName?: string;
+    storySlug?: string;
+    storyFullSlug?: string;
+    component: string;
+    uid?: string;
+    path: string;
+    parentComponent?: string;
+    parentUid?: string;
+    details?: Record<string, unknown>;
+}
+
+export interface ComponentUsageFilters {
+    all?: boolean;
+    withSlug?: string[];
+    startsWith?: string;
+}
+
+export interface ComponentUsageReport {
+    queryName: string;
+    spaceId: string;
+    generatedAt: string;
+    filters: ComponentUsageFilters;
+    totals: {
+        storiesScanned: number;
+        storiesMatched: number;
+        matches: number;
+    };
+    matches: ComponentUsageMatch[];
+}
+
+export interface InspectFetchedStoriesArgs {
+    stories: any[];
+    query: ComponentUsageQuery;
+    spaceId: string;
+    filters?: ComponentUsageFilters;
+}
+
+export interface InspectStoryblokStoriesArgs {
+    query: ComponentUsageQuery;
+    spaceId: string;
+    filters: ComponentUsageFilters;
+    includeFolders?: boolean;
+}

--- a/src/api/inspect/index.ts
+++ b/src/api/inspect/index.ts
@@ -1,0 +1,18 @@
+export {
+    inspectFetchedStories,
+    inspectStoryblokStories,
+    inspectStoryContent,
+} from "./component-usage.js";
+export {
+    discoverComponentUsageQueryFiles,
+    loadComponentUsageQuery,
+    loadComponentUsageQueryFromPath,
+} from "./component-usage-query.js";
+export type {
+    ComponentUsageFilters,
+    ComponentUsageMatch,
+    ComponentUsageQuery,
+    ComponentUsageQueryContext,
+    ComponentUsageReport,
+    ComponentUsageStoryRef,
+} from "./component-usage.types.js";

--- a/src/api/managementApi.ts
+++ b/src/api/managementApi.ts
@@ -2,6 +2,7 @@ import * as assets from "./assets/index.js";
 import * as auth from "./auth/index.js";
 import * as components from "./components/index.js";
 import * as datasources from "./datasources/index.js";
+import * as inspect from "./inspect/index.js";
 import * as plugins from "./plugins/index.js";
 import * as presets from "./presets/index.js";
 import * as roles from "./roles/index.js";
@@ -13,6 +14,7 @@ export const managementApi = {
     auth: { ...auth },
     components: { ...components },
     datasources: { ...datasources },
+    inspect: { ...inspect },
     plugins: { ...plugins },
     presets: { ...presets },
     roles: { ...roles },

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -5,6 +5,7 @@ export const mainDescription = `
     COMMANDS
         sync                    Synchronize components, roles, datasources, plugins, stories, and assets.
         copy                    Copy Storyblok stories or folders between spaces.
+        inspect                 Inspect Storyblok content without writing changes.
         discover                Discover local components and migration config files.
         backup                  Back up Storyblok resources to local JSON files.
         migrate                 Run story or preset data migrations.
@@ -21,7 +22,42 @@ export const mainDescription = `
     EXAMPLES
       $ sb-mig sync components --all
       $ sb-mig migrate content --all --from 12345 --to 12345 --migration file-with-migration --dry-run
+      $ sb-mig inspect component-usage --from 12345 --all --query flex-group-width-child
       $ sb-mig copy stories --sourceSpace 12345 --targetSpace 67890 --what folder/* --where target-folder
+`;
+
+export const inspectDescription = `
+    USAGE
+        $ sb-mig inspect component-usage --from [spaceId] --all --query [query-name]
+        $ sb-mig inspect component-usage --from [spaceId] --withSlug [full_slug] --query [query-name]
+        $ sb-mig inspect component-usage --from [spaceId] --startsWith [prefix] --query [query-name]
+
+    DESCRIPTION
+        Inspect Storyblok story content with a local component usage query file.
+        This command is read-only against Storyblok and writes a local JSON file only when --outputPath is passed.
+
+    COMMANDS
+        component-usage  Find component usage patterns in selected stories.
+
+    FLAGS
+        --from        Source space ID to inspect. Falls back to configured spaceId.
+        --all         Inspect all non-folder stories.
+        --withSlug    Exact story full_slug to inspect. Can be repeated.
+        --startsWith  Filter stories by starts_with prefix.
+        --query       Query file name or path. Looks for *.sb.query.js, *.sb.query.cjs, or *.sb.query.mjs.
+        --outputPath  Optional file path for JSON report output.
+
+    SIDE EFFECTS
+        Read-only against Storyblok. Writes a local JSON report only when --outputPath is passed.
+
+    GOTCHAS
+        Pass exactly one selection mode: --all, --withSlug, or --startsWith.
+        A query file must default-export an object with name and match(node, context).
+        TypeScript query files are planned, but the first implementation supports JS/CJS/MJS query files.
+
+    EXAMPLES
+        $ sb-mig inspect component-usage --from 12345 --all --query flex-group-width-child
+        $ sb-mig inspect component-usage --from 12345 --startsWith landing-pages --query ./queries/flex-group-width-child.sb.query.js --outputPath sbmig/usage/flex-group-width-child.json
 `;
 
 export const storyVersionsDescription = `

--- a/src/cli/commands/inspect.ts
+++ b/src/cli/commands/inspect.ts
@@ -1,0 +1,162 @@
+import type { CLIOptions } from "../../utils/interfaces.js";
+
+import { loadComponentUsageQuery } from "../../api/inspect/component-usage-query.js";
+import { inspectStoryblokStories } from "../../api/inspect/component-usage.js";
+import { createAndSaveToFile } from "../../utils/files.js";
+import Logger from "../../utils/logger.js";
+import { apiConfig } from "../api-config.js";
+import { getFrom } from "../utils/cli-utils.js";
+
+const INSPECT_COMMANDS = {
+    componentUsage: "component-usage",
+};
+
+const normalizeWithSlug = (
+    withSlugFlag: string | string[] | undefined,
+): string[] | undefined => {
+    if (Array.isArray(withSlugFlag)) {
+        return withSlugFlag.filter(Boolean);
+    }
+
+    if (typeof withSlugFlag === "string" && withSlugFlag.length > 0) {
+        return [withSlugFlag];
+    }
+
+    return undefined;
+};
+
+const countSelectionModes = ({
+    all,
+    withSlug,
+    startsWith,
+}: {
+    all?: boolean;
+    withSlug?: string[];
+    startsWith?: string;
+}): number =>
+    [
+        Boolean(all),
+        Boolean(withSlug && withSlug.length > 0),
+        Boolean(startsWith),
+    ].filter(Boolean).length;
+
+const assertValidSelection = ({
+    all,
+    withSlug,
+    startsWith,
+}: {
+    all?: boolean;
+    withSlug?: string[];
+    startsWith?: string;
+}) => {
+    const selectedModes = countSelectionModes({ all, withSlug, startsWith });
+
+    if (selectedModes === 0) {
+        throw new Error(
+            "Missing story selection. Pass exactly one of --all, --withSlug, or --startsWith.",
+        );
+    }
+
+    if (selectedModes > 1) {
+        throw new Error(
+            "Pass only one story selection mode: --all, --withSlug, or --startsWith.",
+        );
+    }
+};
+
+const printComponentUsageSummary = (report: {
+    queryName: string;
+    spaceId: string;
+    totals: {
+        storiesScanned: number;
+        storiesMatched: number;
+        matches: number;
+    };
+    matches: Array<{ storyFullSlug?: string; storySlug?: string }>;
+}) => {
+    Logger.log("Component usage inspection");
+    Logger.log(`Space: ${report.spaceId}`);
+    Logger.log(`Query: ${report.queryName}`);
+    Logger.log(`Stories scanned: ${report.totals.storiesScanned}`);
+    Logger.log(`Stories matched: ${report.totals.storiesMatched}`);
+    Logger.log(`Total matches: ${report.totals.matches}`);
+
+    const countsByStory = report.matches.reduce<Record<string, number>>(
+        (acc, match) => {
+            const slug = match.storyFullSlug || match.storySlug || "[unknown]";
+            acc[slug] = (acc[slug] || 0) + 1;
+            return acc;
+        },
+        {},
+    );
+
+    if (Object.keys(countsByStory).length === 0) {
+        Logger.warning("No matches found.");
+        return;
+    }
+
+    Logger.log("Matches by story:");
+    for (const [slug, count] of Object.entries(countsByStory)) {
+        Logger.log(`- ${slug}: ${count}`);
+    }
+};
+
+export const inspect = async (props: CLIOptions) => {
+    const { input, flags } = props;
+    const command = input[1];
+
+    switch (command) {
+        case INSPECT_COMMANDS.componentUsage: {
+            const from = getFrom(flags, apiConfig);
+            const queryNameOrPath = flags["query"] as string | undefined;
+            const withSlug = normalizeWithSlug(
+                flags["withSlug"] as string | string[] | undefined,
+            );
+            const startsWith =
+                (flags["startsWith"] as string | undefined) || undefined;
+            const all = Boolean(flags["all"]);
+            const outputPath = flags["outputPath"] as string | undefined;
+
+            assertValidSelection({ all, withSlug, startsWith });
+
+            if (!queryNameOrPath) {
+                throw new Error(
+                    "Missing query. Pass --query with a component usage query file name or path.",
+                );
+            }
+
+            const query = await loadComponentUsageQuery(queryNameOrPath);
+            const report = await inspectStoryblokStories(
+                {
+                    query,
+                    spaceId: from,
+                    filters: {
+                        all: all || undefined,
+                        withSlug,
+                        startsWith,
+                    },
+                },
+                apiConfig,
+            );
+
+            printComponentUsageSummary(report);
+
+            if (outputPath) {
+                await createAndSaveToFile(
+                    {
+                        path: outputPath,
+                        res: report,
+                    },
+                    apiConfig,
+                );
+            }
+
+            break;
+        }
+
+        default:
+            throw new Error(
+                "Unknown inspect command. Supported command: component-usage.",
+            );
+    }
+};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import {
     removeDescription,
     initDescription,
     discoverDescription,
+    inspectDescription,
     migrateDescription,
     languagePublishStateDescription,
     storyVersionsDescription,
@@ -254,6 +255,39 @@ app.discover = () => ({
     action: async (cli: any) => {
         const { discover } = await import("./commands/discover.js");
         await discover(cli);
+    },
+});
+
+app.inspect = () => ({
+    cli: meow(inspectDescription, {
+        importMeta: import.meta,
+        booleanDefault: undefined,
+        flags: {
+            from: {
+                type: "string",
+            },
+            all: {
+                type: "boolean",
+                default: false,
+            },
+            withSlug: {
+                type: "string",
+                isMultiple: true,
+            },
+            startsWith: {
+                type: "string",
+            },
+            query: {
+                type: "string",
+            },
+            outputPath: {
+                type: "string",
+            },
+        },
+    }),
+    action: async (cli: any) => {
+        const { inspect } = await import("./commands/inspect.js");
+        await inspect(cli);
     },
 });
 


### PR DESCRIPTION
## Summary
- add read-only `inspect component-usage` CLI command
- add reusable Storyblok component traversal and report generation
- add JS/CJS/MJS query-file loading plus flex-group width-child fixture query
- document the GCTT-3770 implementation plan

## Verification
- npm run lint
- npm run typecheck
- npm run build
- npm run test:unit