### PR TITLE
docs(readme): point to LLM-ready documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,5 @@
-# AI Agent Instructions
+@AGENTS.md
 
-This repository uses **conventional commits** for all commits. When committing, follow the format:
+## Claude Code
 
-```
-<type>(<scope>): <short description>
-
-<body>
-```
-
-Use the following commit types when appropriate:
-
-- `feat` - new features
-- `fix` - bug fixes
-- `chore` - maintenance work
-- `refactor` - code refactoring
-- `docs` - documentation changes
-- `test` - adding or modifying tests
-
-Other commit types from the [Conventional Commits](https://www.conventionalcommits.org/) specification are also allowed.
-
-Every pull request should contain commits that adhere to this style. The repository is configured with commitlint and commitizen to help enforce these rules.
-
-## LLM-ready docs maintenance
-
-The canonical public docs live in the `sb-mig-landing` repository and are exposed at `https://sb-mig.vercel.app`, including `/llms.txt` and `/llms-full.txt`.
-
-When changing this package README or package metadata, keep links to the canonical docs site and LLM entrypoints accurate. Normal package code changes do not require touching the LLM routes. If docs URLs, the canonical domain, or the public docs strategy changes, update this repo's README/package metadata and the matching `sb-mig-landing` docs configuration in the same workstream.
+Claude Code reads this file at session start. `AGENTS.md` is the shared source of truth for this repository's AI-agent instructions; keep shared guidance there so Claude and other coding agents stay aligned.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ This repository uses **conventional commits** for all commits. When committing, 
 
 Use the following commit types when appropriate:
 
-- `feat` – new features
-- `fix` – bug fixes
-- `chore` – maintenance work
-- `refactor` – code refactoring
-- `docs` – documentation changes
-- `test` – adding or modifying tests
+- `feat` - new features
+- `fix` - bug fixes
+- `chore` - maintenance work
+- `refactor` - code refactoring
+- `docs` - documentation changes
+- `test` - adding or modifying tests
 
 Other commit types from the [Conventional Commits](https://www.conventionalcommits.org/) specification are also allowed.
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,20 @@ If you've found an issue or you have feature request - <a href="https://github.c
 [![GitHub issues](https://img.shields.io/github/issues/sb-mig/sb-mig.svg?style=flat-square&v=1)](https://github.com/sb-mig/sb-mig/issues?q=is%3Aopen+is%3Aissue)
 ![npm](https://img.shields.io/npms-io/maintenance-score/sb-mig)
 
+# Documentation
+
+- [Docs site](https://sb-mig.vercel.app) is the canonical documentation for current sb-mig workflows.
+- [Quickstart](https://sb-mig.vercel.app/docs/quickstart) covers installation, credentials, and first safe commands.
+- [CLI reference](https://sb-mig.vercel.app/docs/reference/cli) covers command families and safety conventions.
+- [LLM docs index](https://sb-mig.vercel.app/llms.txt) and [full Markdown corpus](https://sb-mig.vercel.app/llms-full.txt) are available for coding agents and other LLM tools.
+
 # Requirements:
 
 |      |              |
 | ---- | ------------ |
 | Node | 22.x.x or >=24.x.x |
 
-# 6.x.x version released!
+# Current release notes: 6.x.x
 
 ## Important Updates
 
@@ -38,7 +45,11 @@ If you've found an issue or you have feature request - <a href="https://github.c
     - `--publishLanguages` is now `--publicationLanguages`
     - `--preservePublishedLayer` is now `--publicationMode preserve-layers`
 
-# 5.x.x version released!
+# Historical release notes
+
+The sections below are retained for historical context. For current usage, prefer the [docs site](https://sb-mig.vercel.app) and `sb-mig --help`.
+
+## 5.x.x version released!
 
 ## Important Updates
 
@@ -60,13 +71,13 @@ If you've found an issue or you have feature request - <a href="https://github.c
 
 Do not hesitate to get in touch if you encounter any issues or require further clarification on any points.
 
-# 4.x.x version released!
+## 4.x.x version released!
 
 - Whole deployment now, is handled by [semantic-release](https://github.com/semantic-release/semantic-release). And is just normal repository, instead of Lerna monorepo which is not needed anymore, and it was recently unmaintained (now it was passed to `nrwl` to maintain (https://github.com/lerna/lerna/issues/3121) will see what will happen in future with it :)
 - Fromt the code perspective, there are no **breaking changes** between **3.x.x** and **4.x.x** but i'm going to fix some stuff now and add some more functionalities to it. So stay tuned!
 - This Readme, which is also kinda documentation, will also be updated. Cause in some places there is misleading information. The best documentation though is just `sb-mig --help` command.
 
-# 3.x.x version released!
+## 3.x.x version released!
 
 - completely rewritten to simple [Meow](https://github.com/sindresorhus/meow) lib with help of Typescript. Check [migration guide](https://github.com/sb-mig/sb-mig/blob/oclif-research/MIGRATION-GUIDE-v3.md)
 - support native es modules

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "bugs": "https://github.com/sb-mig/sb-mig/issues",
-  "homepage": "https://github.com/sb-mig/sb-mig",
+  "homepage": "https://sb-mig.vercel.app",
   "keywords": [
     "cli",
     "storyblok",


### PR DESCRIPTION
## Summary

- add a prominent canonical documentation block to the README
- link GitHub/npm readers to `/llms.txt` and `/llms-full.txt`
- mark older release sections as historical context
- update package metadata homepage to `https://sb-mig.vercel.app`

Closes #377

## Verification

- `npm run lint`
