### PR TITLE
S1: move roles into api-v2, shim legacy api/roles (pilot)

### DIFF
--- a/__tests__/api-v2/roles.test.ts
+++ b/__tests__/api-v2/roles.test.ts
@@ -1,0 +1,146 @@
+import type { ApiClient } from "../../src/api-v2/client.js";
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+
+import { configToClient } from "../../src/api-v2/requestConfig.js";
+import {
+    getAllRoles,
+    getRole,
+    createRole,
+    updateRole,
+    syncRoles,
+} from "../../src/api-v2/roles/index.js";
+import {
+    createMockApiConfig,
+    createMockRole,
+    createPaginatedResponse,
+    type MockStoryblokClient,
+} from "../mocks/storyblokClient.mock.js";
+
+describe("api-v2/roles", () => {
+    let client: ApiClient;
+    let sbApi: MockStoryblokClient;
+
+    beforeEach(() => {
+        client = configToClient(createMockApiConfig({ spaceId: "777" }));
+        sbApi = client.sbApi as unknown as MockStoryblokClient;
+    });
+
+    describe("getAllRoles", () => {
+        it("fetches space_roles for the client's space", async () => {
+            const roles = [createMockRole({ role: "Editor" })];
+            sbApi.get.mockResolvedValue(
+                createPaginatedResponse(roles, "space_roles"),
+            );
+
+            const result = await getAllRoles(client);
+
+            expect(sbApi.get).toHaveBeenCalledWith(
+                "spaces/777/space_roles/",
+                expect.objectContaining({ per_page: 100, page: 1 }),
+            );
+            expect(result).toEqual(roles);
+        });
+
+        it("returns an empty list when the space has no roles (404)", async () => {
+            sbApi.get.mockRejectedValue({ response: { status: 404 } });
+
+            const result = await getAllRoles(client);
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("getRole", () => {
+        it("returns the matching role", async () => {
+            const editor = createMockRole({ role: "Editor" });
+            const admin = createMockRole({ role: "Admin" });
+            sbApi.get.mockResolvedValue(
+                createPaginatedResponse([editor, admin], "space_roles"),
+            );
+
+            const result = await getRole(client, "Admin");
+
+            expect(result).toEqual([admin]);
+        });
+
+        it("returns false when no role matches", async () => {
+            sbApi.get.mockResolvedValue(
+                createPaginatedResponse(
+                    [createMockRole({ role: "Editor" })],
+                    "space_roles",
+                ),
+            );
+
+            const result = await getRole(client, "Nope");
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe("createRole / updateRole", () => {
+        it("POSTs a new role wrapped in space_role", async () => {
+            sbApi.post.mockResolvedValue({ data: { space_role: { id: 1 } } });
+
+            await createRole(client, { role: "Editor" });
+
+            expect(sbApi.post).toHaveBeenCalledWith("spaces/777/space_roles/", {
+                space_role: { role: "Editor" },
+            });
+        });
+
+        it("PUTs an existing role by id", async () => {
+            sbApi.put.mockResolvedValue({ data: {} });
+
+            await updateRole(client, { id: 42, role: "Editor" });
+
+            expect(sbApi.put).toHaveBeenCalledWith("spaces/777/space_roles/42", {
+                space_role: { id: 42, role: "Editor" },
+            });
+        });
+    });
+
+    describe("syncRoles", () => {
+        beforeEach(() => {
+            // remote space already has an "Editor" role
+            sbApi.get.mockResolvedValue(
+                createPaginatedResponse(
+                    [createMockRole({ id: 10, role: "Editor" })],
+                    "space_roles",
+                ),
+            );
+            sbApi.post.mockResolvedValue({ data: {} });
+            sbApi.put.mockResolvedValue({ data: {} });
+        });
+
+        it("updates existing, creates new, skips invalid", async () => {
+            const result = await syncRoles(client, {
+                roles: [
+                    { role: "Editor" }, // exists -> update
+                    { role: "Reviewer" }, // new -> create
+                    { foo: "bar" }, // invalid -> skip
+                ],
+            });
+
+            expect(result.updated).toEqual(["Editor"]);
+            expect(result.created).toEqual(["Reviewer"]);
+            expect(result.skipped).toEqual(["unknown"]);
+            expect(result.errors).toEqual([]);
+            expect(sbApi.put).toHaveBeenCalledTimes(1);
+            expect(sbApi.post).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not write in dryRun mode but still reports the plan", async () => {
+            const result = await syncRoles(client, {
+                roles: [{ role: "Editor" }, { role: "Reviewer" }],
+                dryRun: true,
+            });
+
+            expect(result.updated).toEqual(["Editor"]);
+            expect(result.created).toEqual(["Reviewer"]);
+            expect(sbApi.put).not.toHaveBeenCalled();
+            expect(sbApi.post).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/api-v2/roles/index.ts
+++ b/src/api-v2/roles/index.ts
@@ -1,15 +1,47 @@
+import type { SyncResult } from "../../api/sync/sync.types.js";
 import type { ApiClient } from "../client.js";
 
 import { getAllItemsWithPagination } from "../../api/utils/request.js";
+import Logger from "../../utils/logger.js";
 
+/*
+ * Canonical roles implementation (api-v2).
+ *
+ * The legacy `api/roles/roles.ts` now shims to these functions via
+ * `configToClient`. Behaviour (logging, 404 handling, create/update/skip/dry-run
+ * sync) is preserved 1:1 from the previous `api/roles` implementation so the CLI
+ * stays byte-stable. See SDK-REFACTOR.md (S1).
+ *
+ * NOTE: console logging via Logger is kept for CLI parity; migrating roles to the
+ * structured progress contract is tracked under F5.
+ */
+
+// GET all
 export async function getAllRoles(client: ApiClient): Promise<any> {
-    const spaceId = client.spaceId;
+    const { sbApi, spaceId } = client;
+    Logger.log("Trying to get all roles.");
+
+    // TODO: All Roles doesn't support pagination...
+    // https://github.com/storyblok/storyblok-js-client/issues/535
     return getAllItemsWithPagination({
         apiFn: ({ per_page, page }) =>
-            client.sbApi.get(`spaces/${spaceId}/space_roles/`, {
-                per_page,
-                page,
-            }),
+            sbApi
+                .get(`spaces/${spaceId}/space_roles/`, { per_page, page })
+                .then((res: any) => {
+                    Logger.log(`Amount of roles: ${res.total}`);
+                    return res;
+                })
+                .catch((err: any) => {
+                    if (err.response?.status === 404) {
+                        Logger.error(
+                            `There is no roles in your Storyblok ${spaceId} space.`,
+                        );
+                        return true;
+                    } else {
+                        Logger.error(err);
+                        return false;
+                    }
+                }),
         params: {
             spaceId,
         },
@@ -17,28 +49,137 @@ export async function getAllRoles(client: ApiClient): Promise<any> {
     });
 }
 
+// GET one
 export async function getRole(
     client: ApiClient,
-    roleName: string,
+    roleName: string | undefined,
 ): Promise<any> {
-    const roles = await getAllRoles(client);
-    const match = roles.filter((r: any) => r.role === roleName);
-    if (Array.isArray(match) && match.length === 0) return false;
-    return match;
+    Logger.log(`Trying to get '${roleName}' role.`);
+
+    return getAllRoles(client)
+        .then((res: any) => res.filter((role: any) => role.role === roleName))
+        .then((res: any) => {
+            if (Array.isArray(res) && res.length === 0) {
+                Logger.warning(`There is no role named '${roleName}'`);
+                return false;
+            }
+            return res;
+        })
+        .catch((err: any) => Logger.error(err));
 }
 
+// POST
 export async function createRole(client: ApiClient, role: any): Promise<any> {
-    const spaceId = client.spaceId;
-    return client.sbApi
+    const { sbApi, spaceId } = client;
+
+    return sbApi
         .post(`spaces/${spaceId}/space_roles/`, { space_role: role } as any)
-        .then((res: any) => res.data);
+        .then((res: any) => {
+            Logger.success(`Role '${role.role}' has been created.`);
+            return res.data;
+        })
+        .catch((err: any) => {
+            Logger.error("error happened... :(");
+            console.log(
+                `${err.message} in migration of ${role.role} in createRole function`,
+            );
+            throw err;
+        });
 }
 
+// PUT
 export async function updateRole(client: ApiClient, role: any): Promise<any> {
-    const spaceId = client.spaceId;
-    return client.sbApi
+    const { sbApi, spaceId } = client;
+
+    return sbApi
         .put(`spaces/${spaceId}/space_roles/${role.id}`, {
             space_role: role,
         } as any)
-        .then((res: any) => res.data);
+        .then((res: any) => {
+            Logger.success(`Role '${role.role}' has been updated.`);
+            return res.data;
+        })
+        .catch((err: any) => {
+            Logger.error("error happened... :(");
+            console.log(
+                `${err.message} in migration of ${role.role} in updateRole function`,
+            );
+            throw err;
+        });
+}
+
+/**
+ * Data-only role sync. Reconciles the provided role definitions against the
+ * remote space: existing roles (matched by `role`) are updated, new ones are
+ * created, invalid entries are skipped. With `dryRun` no writes happen but the
+ * planned changes are still reported.
+ */
+export async function syncRoles(
+    client: ApiClient,
+    { roles, dryRun }: { roles: any[]; dryRun?: boolean },
+): Promise<SyncResult> {
+    const result: SyncResult = {
+        created: [],
+        updated: [],
+        skipped: [],
+        errors: [],
+    };
+
+    if (dryRun) {
+        Logger.warning(
+            "[dry-run] Role sync will only read remote data and report planned changes.",
+        );
+    }
+
+    const space_roles_raw = await getAllRoles(client);
+    const space_roles = Array.isArray(space_roles_raw) ? space_roles_raw : [];
+
+    const rolesToUpdate: any[] = [];
+    const rolesToCreate: any[] = [];
+
+    for (const role of roles) {
+        if (!role || typeof role !== "object" || !("role" in role)) {
+            result.skipped.push(String((role as any)?.role ?? "unknown"));
+            continue;
+        }
+
+        const shouldBeUpdated = space_roles.find(
+            (remoteRole: any) => role.role === remoteRole.role,
+        );
+        if (shouldBeUpdated) {
+            rolesToUpdate.push({ id: shouldBeUpdated.id, ...role });
+        } else {
+            rolesToCreate.push(role);
+        }
+    }
+
+    const updateResults = dryRun
+        ? rolesToUpdate.map(() => ({ status: "fulfilled" as const }))
+        : await Promise.allSettled(
+              rolesToUpdate.map((role) => updateRole(client, role)),
+          );
+    updateResults.forEach((r: any, idx) => {
+        const name = String(rolesToUpdate[idx]?.role ?? "unknown");
+        if (dryRun) {
+            Logger.warning(`[dry-run] Would update role '${name}'.`);
+        }
+        if (r.status === "fulfilled") result.updated.push(name);
+        else result.errors.push({ name, message: String(r.reason) });
+    });
+
+    const createResults = dryRun
+        ? rolesToCreate.map(() => ({ status: "fulfilled" as const }))
+        : await Promise.allSettled(
+              rolesToCreate.map((role) => createRole(client, role)),
+          );
+    createResults.forEach((r: any, idx) => {
+        const name = String(rolesToCreate[idx]?.role ?? "unknown");
+        if (dryRun) {
+            Logger.warning(`[dry-run] Would create role '${name}'.`);
+        }
+        if (r.status === "fulfilled") result.created.push(name);
+        else result.errors.push({ name, message: String(r.reason) });
+    });
+
+    return result;
 }

--- a/src/api-v2/sync/index.ts
+++ b/src/api-v2/sync/index.ts
@@ -4,8 +4,8 @@ import type { SyncProgressCallback, SyncResult } from "./types.js";
 import { syncComponentsData } from "../../api/components/components.sync.js";
 import { syncDatasourcesData } from "../../api/datasources/datasources.js";
 import { syncPluginsData } from "../../api/plugins/plugins.js";
-import { syncRolesData } from "../../api/roles/roles.js";
 import { toRequestConfig } from "../requestConfig.js";
+import { syncRoles as syncRolesV2 } from "../roles/index.js";
 
 export async function syncComponents(
     client: ApiClient,
@@ -45,10 +45,7 @@ export async function syncRoles(
     client: ApiClient,
     args: { roles: any[]; dryRun?: boolean },
 ): Promise<SyncResult> {
-    return (await syncRolesData(
-        { roles: args.roles, dryRun: args.dryRun },
-        toRequestConfig(client),
-    )) as any;
+    return syncRolesV2(client, { roles: args.roles, dryRun: args.dryRun });
 }
 
 export async function syncPlugins(

--- a/src/api/roles/roles.ts
+++ b/src/api/roles/roles.ts
@@ -5,171 +5,52 @@ import type {
     UpdateRole,
 } from "./roles.types.js";
 import type { SyncResult } from "../sync/sync.types.js";
+import type { RequestBaseConfig } from "../utils/request.js";
 
-import Logger from "../../utils/logger.js";
-import { getAllItemsWithPagination } from "../utils/request.js";
+import { configToClient } from "../../api-v2/requestConfig.js";
+import {
+    createRole as createRoleV2,
+    getAllRoles as getAllRolesV2,
+    getRole as getRoleV2,
+    syncRoles as syncRolesV2,
+    updateRole as updateRoleV2,
+} from "../../api-v2/roles/index.js";
+
+/*
+ * Strategy-B shim layer (S1 pilot).
+ *
+ * The canonical roles implementation now lives in `api-v2/roles`. These legacy
+ * config-based exports delegate to it via `configToClient`, keeping every existing
+ * caller (CLI, managementApi, backup) on the exact same code path while the data
+ * logic lives in the SDK layer. See SDK-REFACTOR.md (S1).
+ *
+ * The file-based sync wrapper still lives in `roles.sync.ts`.
+ */
 
 // POST
 export const createRole: CreateRole = (role: any, config) => {
-    const { sbApi, spaceId } = config;
-
-    return sbApi
-        .post(`spaces/${spaceId}/space_roles/`, {
-            space_role: role,
-        } as any)
-        .then(() => {
-            Logger.success(`Role '${role.role}' has been created.`);
-        })
-        .catch((err) => {
-            Logger.error("error happened... :(");
-            console.log(
-                `${err.message} in migration of ${role.role} in createRole function`,
-            );
-            throw err;
-        });
+    return createRoleV2(configToClient(config), role);
 };
 
 // PUT
 export const updateRole: UpdateRole = (role, config) => {
-    const { sbApi, spaceId } = config;
-
-    return sbApi
-        .put(`spaces/${spaceId}/space_roles/${role.id}`, {
-            space_role: role,
-        } as any)
-        .then(() => {
-            Logger.success(`Role '${role.role}' has been updated.`);
-        })
-        .catch((err) => {
-            Logger.error("error happened... :(");
-            console.log(
-                `${err.message} in migration of ${role.role} in updateRole function`,
-            );
-            throw err;
-        });
+    return updateRoleV2(configToClient(config), role);
 };
 
-// GET
-export const getAllRoles: GetAllRoles = async (config) => {
-    const { sbApi, spaceId } = config;
-    Logger.log("Trying to get all roles.");
-
-    // TODO: All Roles doesnt support pagination...
-    // https://github.com/storyblok/storyblok-js-client/issues/535
-    return getAllItemsWithPagination({
-        apiFn: ({ per_page, page }) =>
-            sbApi
-                .get(`spaces/${spaceId}/space_roles/`, { per_page, page })
-                .then((res) => {
-                    Logger.log(`Amount of roles: ${res.total}`);
-
-                    return res;
-                })
-                .catch((err) => {
-                    if (err.response.status === 404) {
-                        Logger.error(
-                            `There is no roles in your Storyblok ${spaceId} space.`,
-                        );
-                        return true;
-                    } else {
-                        Logger.error(err);
-                        return false;
-                    }
-                }),
-        params: {
-            spaceId,
-        },
-        itemsKey: "space_roles",
-    });
+// GET all
+export const getAllRoles: GetAllRoles = (config) => {
+    return getAllRolesV2(configToClient(config));
 };
 
-// GET
-export const getRole: GetRole = async (
-    roleName: string | undefined,
-    config,
-) => {
-    Logger.log(`Trying to get '${roleName}' role.`);
-
-    return getAllRoles(config)
-        .then((res) => res.filter((role: any) => role.role === roleName))
-        .then((res) => {
-            if (Array.isArray(res) && res.length === 0) {
-                Logger.warning(`There is no role named '${roleName}'`);
-                return false;
-            }
-            return res;
-        })
-        .catch((err) => Logger.error(err));
+// GET one
+export const getRole: GetRole = (roleName, config) => {
+    return getRoleV2(configToClient(config), roleName);
 };
 
-export const syncRolesData = async (
+// Data-only sync
+export const syncRolesData = (
     { roles, dryRun }: { roles: any[]; dryRun?: boolean },
-    config: any,
+    config: RequestBaseConfig,
 ): Promise<SyncResult> => {
-    const result: SyncResult = {
-        created: [],
-        updated: [],
-        skipped: [],
-        errors: [],
-    };
-
-    if (dryRun) {
-        Logger.warning(
-            "[dry-run] Role sync will only read remote data and report planned changes.",
-        );
-    }
-
-    const space_roles_raw = await getAllRoles(config);
-    const space_roles = Array.isArray(space_roles_raw) ? space_roles_raw : [];
-
-    const rolesToUpdate: any[] = [];
-    const rolesToCreate: any[] = [];
-
-    for (const role of roles) {
-        if (!role || typeof role !== "object" || !("role" in role)) {
-            result.skipped.push(String((role as any)?.role ?? "unknown"));
-            continue;
-        }
-
-        const shouldBeUpdated = space_roles.find(
-            (remoteRole: any) => role.role === remoteRole.role,
-        );
-        if (shouldBeUpdated) {
-            rolesToUpdate.push({ id: shouldBeUpdated.id, ...role });
-        } else {
-            rolesToCreate.push(role);
-        }
-    }
-
-    const updateResults = dryRun
-        ? rolesToUpdate.map(() => ({ status: "fulfilled" as const }))
-        : await Promise.allSettled(
-              rolesToUpdate.map((role) => updateRole(role, config) as any),
-          );
-    updateResults.forEach((r: any, idx) => {
-        const name = String(rolesToUpdate[idx]?.role ?? "unknown");
-        if (dryRun) {
-            Logger.warning(`[dry-run] Would update role '${name}'.`);
-        }
-        if (r.status === "fulfilled") result.updated.push(name);
-        else result.errors.push({ name, message: String(r.reason) });
-    });
-
-    const createResults = dryRun
-        ? rolesToCreate.map(() => ({ status: "fulfilled" as const }))
-        : await Promise.allSettled(
-              rolesToCreate.map((role) => createRole(role, config) as any),
-          );
-    createResults.forEach((r: any, idx) => {
-        const name = String(rolesToCreate[idx]?.role ?? "unknown");
-        if (dryRun) {
-            Logger.warning(`[dry-run] Would create role '${name}'.`);
-        }
-        if (r.status === "fulfilled") result.created.push(name);
-        else result.errors.push({ name, message: String(r.reason) });
-    });
-
-    return result;
+    return syncRolesV2(configToClient(config), { roles, dryRun });
 };
-
-// File-based sync wrapper lives in `roles.sync.ts` to keep this module CJS-safe.


### PR DESCRIPTION
First **Strategy-B slice** — the roles pilot ([MAR-1441](https://linear.app/marckraw/issue/MAR-1441)). Validates the move → shim pattern that every resource will follow. **Behavior-preserving**: the CLI path is byte-identical.

## What changed
- **Canonical impl moved to `api-v2/roles`** — CRUD (`getAllRoles`/`getRole`/`createRole`/`updateRole`) + data-only `syncRoles`, operating on `ApiClient`. Logging, 404 handling, and create/update/skip/dry-run logic preserved **1:1** from the old `api/roles`. (Replaces the previously divergent, simplified v2 roles stub.)
- **`api/roles/roles.ts` is now a thin shim** — delegates to `api-v2/roles` via `configToClient` (the F2 primitive). Every existing caller (CLI, `managementApi`, backup) stays on the exact same code path.
- **`api-v2/sync` calls `api-v2/roles` directly** — removes a v2 → old-api dependency.

## How to review
The substance is `src/api-v2/roles/index.ts` (the moved logic) and `src/api/roles/roles.ts` (now ~57 lines of shims). Diff the v2 roles against the old `api/roles/roles.ts` to confirm logic parity.

One pragmatic call: the moved code keeps `Logger` console output for CLI parity. Migrating roles to the structured progress contract (so the pure core is log-free) is tracked under **F5** — noted in the code.

## Verification
- ✅ 472 unit tests pass (incl. 8 new `__tests__/api-v2/roles.test.ts`).
- ✅ typecheck + eslint (zero-warnings) clean.
- ✅ Runtime smoke in **both** formats: ESM `managementApi.roles` and CJS `dist-cjs/api-v2` both load through the real shim graph; `sb-mig sync --help` renders (no import cycle).

## Scope / next
- **Deferred:** the direct CLI-import rewire (S1 step 3) — the shim already makes the CLI run on api-v2, so this is cleanup, not behavior.
- **Gated on F1:** live `test:api-live` + `test:e2e` parity (needs a disposable scratch-space's `STORYBLOK_OAUTH_TOKEN` + `STORYBLOK_SPACE_ID`).
- With the pattern proven here, the leaf slices S2 (datasources) / S3 (plugins) / S24 (spaces/auth/assets) can follow the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)