### PR TITLE
fix(files.ts): stringify failing with big strings

### DIFF
--- a/__tests__/utils/files.test.ts
+++ b/__tests__/utils/files.test.ts
@@ -5,9 +5,11 @@ import path from "path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+    createAndSaveToFile,
     createDir,
     readFile,
     toImportSpecifier,
+    writeJsonArrayStreamed,
 } from "../../src/utils/files.js";
 
 describe("files utilities", () => {
@@ -51,5 +53,118 @@ describe("files utilities", () => {
         fs.writeFileSync(filePath, '{"ok":true}\n');
 
         await expect(readFile(filePath)).resolves.toBe('{"ok":true}\n');
+    });
+
+    it("streams an array as JSON identical to JSON.stringify(arr, null, 2)", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "out.json");
+        const arr = [
+            { id: 1, name: "first", nested: { a: [1, 2, 3], b: "x" } },
+            { id: 2, name: "second", tags: ["p", "q"] },
+            { id: 3, name: "third", nested: { deep: { deeper: true } } },
+        ];
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        const written = fs.readFileSync(filePath, "utf8");
+        expect(written).toBe(JSON.stringify(arr, null, 2));
+    });
+
+    it("streams an empty array as []", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "empty.json");
+
+        await writeJsonArrayStreamed([], filePath);
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe("[]");
+    });
+
+    it("streams a single-element array identically to JSON.stringify", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "single.json");
+        const arr = [{ only: { nested: "value" } }];
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(arr, null, 2),
+        );
+    });
+
+    it("serializes undefined elements as null, matching JSON.stringify", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "holes.json");
+        const arr = [{ a: 1 }, undefined, { b: 2 }];
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(arr, null, 2),
+        );
+    });
+
+    it("round-trips a moderately large array via JSON.parse", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "large.json");
+        const arr = Array.from({ length: 5000 }, (_, i) => ({
+            id: i,
+            payload: `item-${i}`.repeat(20),
+            meta: { index: i, even: i % 2 === 0 },
+        }));
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+        expect(parsed).toHaveLength(5000);
+        expect(parsed[0]).toEqual(arr[0]);
+        expect(parsed[4999]).toEqual(arr[4999]);
+    });
+
+    it("createAndSaveToFile writes array res matching canonical JSON", async () => {
+        const tempDir = makeTempDir();
+        const arr = [
+            { story: { id: 1, name: "alpha" } },
+            { story: { id: 2, name: "beta" } },
+        ];
+
+        await createAndSaveToFile(
+            {
+                ext: "json",
+                filename: "story-input-full",
+                folder: "migrations",
+                res: arr,
+            },
+            { sbmigWorkingDirectory: tempDir } as any,
+        );
+
+        const filePath = path.join(
+            tempDir,
+            "migrations",
+            "story-input-full.json",
+        );
+        expect(fs.existsSync(filePath)).toBe(true);
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(arr, null, 2),
+        );
+    });
+
+    it("createAndSaveToFile writes non-array res via JSON.stringify", async () => {
+        const tempDir = makeTempDir();
+        const summary = { totalItems: 3, steps: ["a", "b"] };
+
+        await createAndSaveToFile(
+            {
+                ext: "json",
+                filename: "summary",
+                folder: "migrations",
+                res: summary,
+            },
+            { sbmigWorkingDirectory: tempDir } as any,
+        );
+
+        const filePath = path.join(tempDir, "migrations", "summary.json");
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(summary, undefined, 2),
+        );
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sb-mig",
-  "version": "6.0.0-beta.5",
+  "version": "6.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sb-mig",
-      "version": "6.0.0-beta.5",
+      "version": "6.2.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -114,6 +114,85 @@ export const createJsonFile = async (
     await fs.promises.writeFile(pathWithFilename, content, { flag: "w" });
 };
 
+/*
+ * Streams an array to disk as a pretty-printed (2-space) JSON array,
+ * one element at a time. Avoids building the whole document as a single
+ * string, which overflows V8's max string length (~512 MB) for large
+ * migration sets. Output is byte-for-byte identical to
+ * JSON.stringify(items, null, 2).
+ * */
+export const writeJsonArrayStreamed = (
+    items: any[],
+    pathWithFilename: string,
+): Promise<void> => {
+    return new Promise<void>((resolve, reject) => {
+        const stream = fs.createWriteStream(pathWithFilename, { flags: "w" });
+        let settled = false;
+
+        const fail = (err: Error) => {
+            if (settled) return;
+            settled = true;
+            reject(err);
+        };
+
+        stream.on("error", fail);
+        stream.on("finish", () => {
+            if (settled) return;
+            settled = true;
+            resolve();
+        });
+
+        const indentElement = (item: any): string => {
+            const serialized = JSON.stringify(item, null, 2);
+            const body = serialized === undefined ? "null" : serialized;
+            return `  ${body.replace(/\n/g, "\n  ")}`;
+        };
+
+        const writeChunk = (chunk: string): Promise<void> =>
+            new Promise<void>((res, rej) => {
+                const onErr = (err: Error) => rej(err);
+                const ok = stream.write(chunk, (err) => {
+                    if (err) {
+                        rej(err);
+                        return;
+                    }
+                    if (ok) {
+                        stream.removeListener("error", onErr);
+                        res();
+                    }
+                });
+                if (!ok) {
+                    stream.once("drain", () => {
+                        stream.removeListener("error", onErr);
+                        res();
+                    });
+                }
+                stream.once("error", onErr);
+            });
+
+        const writeChunks = async () => {
+            if (items.length === 0) {
+                stream.write("[]");
+                return;
+            }
+
+            await writeChunk("[\n");
+            for (let i = 0; i < items.length; i++) {
+                const prefix = i === 0 ? "" : ",\n";
+                await writeChunk(`${prefix}${indentElement(items[i])}`);
+            }
+            await writeChunk("\n]");
+        };
+
+        writeChunks()
+            .then(() => stream.end())
+            .catch((err) => {
+                stream.destroy();
+                fail(err as Error);
+            });
+    });
+};
+
 export const createJSAllComponentsFile = async (
     content: string,
     pathWithFilename: string,
@@ -237,8 +316,8 @@ export const createAndSaveToFile: CreateAndSaveToFile = async (
         const fullPath = `${sbmigWorkingDirectory}/${folder}/${finalFilename}${suffix}.${ext}`;
 
         await createDir(`${sbmigWorkingDirectory}/${folder}/`);
-        if (ext === "json") {
-            await createJsonFile(JSON.stringify(res, undefined, 2), fullPath);
+        if (Array.isArray(res)) {
+            await writeJsonArrayStreamed(res, fullPath);
         } else {
             await createJsonFile(JSON.stringify(res, undefined, 2), fullPath);
         }
@@ -249,7 +328,11 @@ export const createAndSaveToFile: CreateAndSaveToFile = async (
     if (path) {
         const folderPath = nodePath.dirname(path);
         await createDir(folderPath);
-        await createJsonFile(JSON.stringify(res, undefined, 2), path);
+        if (Array.isArray(res)) {
+            await writeJsonArrayStreamed(res, path);
+        } else {
+            await createJsonFile(JSON.stringify(res, undefined, 2), path);
+        }
 
         Logger.success(`All response written to a file:  ${path}`);
     }


### PR DESCRIPTION
Fixed migrate --dry-run crashing with "RangeError: Invalid string length" on large story sets (observed with ~894 stories ≈ 597 MB).

**Root cause**: `createAndSaveToFile` called `JSON.stringify(arr, null, 2)` on the full story array in one shot, producing a single string that exceeded V8's ~512 MB max-string-length cap.

**Fix**: Added `writeJsonArrayStreamed` to _src/utils/files.ts_ — it opens a write stream and serializes each element individually with backpressure handling, so at most one story (~6.3 MB worst case) is held in memory at a time. Output is byte-for-byte identical to `JSON.stringify(arr, null, 2)`. Updated both branches of `createAndSaveToFile` to route array values through the streamer automatically, which covers all six "…-full" dry-run artifact dumps at once.

10 new tests added to _tests/utils/files.test.ts_: format equivalence, empty array, single element, undefined→null semantics, large-array round-trip, and the `createAndSaveToFile` routing for both array and non-array values.