### PR TITLE
fix(files): make streamed JSON writes atomic

### DIFF
--- a/__tests__/utils/files.test.ts
+++ b/__tests__/utils/files.test.ts
@@ -167,4 +167,46 @@ describe("files utilities", () => {
             JSON.stringify(summary, undefined, 2),
         );
     });
+
+    it("preserves an existing target file when array streaming fails", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "story-to-migrate.json");
+        const circular: any = { id: 2 };
+        circular.self = circular;
+        fs.writeFileSync(filePath, '{"previous":true}');
+
+        await expect(
+            writeJsonArrayStreamed([{ id: 1 }, circular], filePath),
+        ).rejects.toThrow(/circular/i);
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe('{"previous":true}');
+        expect(
+            fs.readdirSync(tempDir).filter((name) => name.endsWith(".tmp")),
+        ).toEqual([]);
+    });
+
+    it("createAndSaveToFile rejects failed array writes without final artifact", async () => {
+        const tempDir = makeTempDir();
+        const circular: any = { story: { id: 2 } };
+        circular.self = circular;
+
+        await expect(
+            createAndSaveToFile(
+                {
+                    ext: "json",
+                    filename: "story-to-migrate",
+                    folder: "migrations",
+                    res: [{ story: { id: 1 } }, circular],
+                },
+                { sbmigWorkingDirectory: tempDir } as any,
+            ),
+        ).rejects.toThrow(/circular/i);
+
+        const folderPath = path.join(tempDir, "migrations");
+        const filePath = path.join(folderPath, "story-to-migrate.json");
+        expect(fs.existsSync(filePath)).toBe(false);
+        expect(
+            fs.readdirSync(folderPath).filter((name) => name.endsWith(".tmp")),
+        ).toEqual([]);
+    });
 });

--- a/__tests__/utils/files.test.ts
+++ b/__tests__/utils/files.test.ts
@@ -5,9 +5,11 @@ import path from "path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+    createAndSaveToFile,
     createDir,
     readFile,
     toImportSpecifier,
+    writeJsonArrayStreamed,
 } from "../../src/utils/files.js";
 
 describe("files utilities", () => {
@@ -51,5 +53,118 @@ describe("files utilities", () => {
         fs.writeFileSync(filePath, '{"ok":true}\n');
 
         await expect(readFile(filePath)).resolves.toBe('{"ok":true}\n');
+    });
+
+    it("streams an array as JSON identical to JSON.stringify(arr, null, 2)", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "out.json");
+        const arr = [
+            { id: 1, name: "first", nested: { a: [1, 2, 3], b: "x" } },
+            { id: 2, name: "second", tags: ["p", "q"] },
+            { id: 3, name: "third", nested: { deep: { deeper: true } } },
+        ];
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        const written = fs.readFileSync(filePath, "utf8");
+        expect(written).toBe(JSON.stringify(arr, null, 2));
+    });
+
+    it("streams an empty array as []", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "empty.json");
+
+        await writeJsonArrayStreamed([], filePath);
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe("[]");
+    });
+
+    it("streams a single-element array identically to JSON.stringify", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "single.json");
+        const arr = [{ only: { nested: "value" } }];
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(arr, null, 2),
+        );
+    });
+
+    it("serializes undefined elements as null, matching JSON.stringify", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "holes.json");
+        const arr = [{ a: 1 }, undefined, { b: 2 }];
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(arr, null, 2),
+        );
+    });
+
+    it("round-trips a moderately large array via JSON.parse", async () => {
+        const tempDir = makeTempDir();
+        const filePath = path.join(tempDir, "large.json");
+        const arr = Array.from({ length: 5000 }, (_, i) => ({
+            id: i,
+            payload: `item-${i}`.repeat(20),
+            meta: { index: i, even: i % 2 === 0 },
+        }));
+
+        await writeJsonArrayStreamed(arr, filePath);
+
+        const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+        expect(parsed).toHaveLength(5000);
+        expect(parsed[0]).toEqual(arr[0]);
+        expect(parsed[4999]).toEqual(arr[4999]);
+    });
+
+    it("createAndSaveToFile writes array res matching canonical JSON", async () => {
+        const tempDir = makeTempDir();
+        const arr = [
+            { story: { id: 1, name: "alpha" } },
+            { story: { id: 2, name: "beta" } },
+        ];
+
+        await createAndSaveToFile(
+            {
+                ext: "json",
+                filename: "story-input-full",
+                folder: "migrations",
+                res: arr,
+            },
+            { sbmigWorkingDirectory: tempDir } as any,
+        );
+
+        const filePath = path.join(
+            tempDir,
+            "migrations",
+            "story-input-full.json",
+        );
+        expect(fs.existsSync(filePath)).toBe(true);
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(arr, null, 2),
+        );
+    });
+
+    it("createAndSaveToFile writes non-array res via JSON.stringify", async () => {
+        const tempDir = makeTempDir();
+        const summary = { totalItems: 3, steps: ["a", "b"] };
+
+        await createAndSaveToFile(
+            {
+                ext: "json",
+                filename: "summary",
+                folder: "migrations",
+                res: summary,
+            },
+            { sbmigWorkingDirectory: tempDir } as any,
+        );
+
+        const filePath = path.join(tempDir, "migrations", "summary.json");
+        expect(fs.readFileSync(filePath, "utf8")).toBe(
+            JSON.stringify(summary, undefined, 2),
+        );
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sb-mig",
-  "version": "6.0.0-beta.5",
+  "version": "6.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sb-mig",
-      "version": "6.0.0-beta.5",
+      "version": "6.2.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -4,6 +4,8 @@ import * as fs from "fs";
 import { writeFile } from "fs";
 import { createRequire } from "module";
 import nodePath from "path";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
 import { pathToFileURL } from "url";
 
 import pkg from "ncp";
@@ -125,72 +127,68 @@ export const writeJsonArrayStreamed = (
     items: any[],
     pathWithFilename: string,
 ): Promise<void> => {
-    return new Promise<void>((resolve, reject) => {
-        const stream = fs.createWriteStream(pathWithFilename, { flags: "w" });
-        let settled = false;
+    const directory = nodePath.dirname(pathWithFilename);
+    const basename = nodePath.basename(pathWithFilename);
+    const tempPath = nodePath.join(
+        directory,
+        `.${basename}.${process.pid}.${Date.now()}.${Math.random()
+            .toString(36)
+            .slice(2)}.tmp`,
+    );
+    const itemCount = items.length;
+    let expectedBytes = 0;
+    let serializedItems = 0;
 
-        const fail = (err: Error) => {
-            if (settled) return;
-            settled = true;
-            reject(err);
-        };
+    const trackChunk = (chunk: string) => {
+        expectedBytes += Buffer.byteLength(chunk);
+        return chunk;
+    };
 
-        stream.on("error", fail);
-        stream.on("finish", () => {
-            if (settled) return;
-            settled = true;
-            resolve();
+    const indentElement = (item: any): string => {
+        const serialized = JSON.stringify(item, null, 2);
+        const body = serialized === undefined ? "null" : serialized;
+        return `  ${body.replace(/\n/g, "\n  ")}`;
+    };
+
+    function* jsonArrayChunks() {
+        if (itemCount === 0) {
+            yield trackChunk("[]");
+            return;
+        }
+
+        yield trackChunk("[\n");
+        for (let i = 0; i < itemCount; i++) {
+            const prefix = i === 0 ? "" : ",\n";
+            yield trackChunk(`${prefix}${indentElement(items[i])}`);
+            serializedItems++;
+        }
+        yield trackChunk("\n]");
+    }
+
+    return pipeline(
+        Readable.from(jsonArrayChunks()),
+        fs.createWriteStream(tempPath, { flags: "wx" }),
+    )
+        .then(async () => {
+            if (serializedItems !== itemCount) {
+                throw new Error(
+                    `Incomplete JSON array stream for ${pathWithFilename}: expected ${itemCount} item(s), serialized ${serializedItems}.`,
+                );
+            }
+
+            const stats = await fs.promises.stat(tempPath);
+            if (stats.size !== expectedBytes) {
+                throw new Error(
+                    `Incomplete JSON array stream for ${pathWithFilename}: expected ${expectedBytes} byte(s), wrote ${stats.size}.`,
+                );
+            }
+
+            await fs.promises.rename(tempPath, pathWithFilename);
+        })
+        .catch(async (err) => {
+            await fs.promises.rm(tempPath, { force: true });
+            throw err;
         });
-
-        const indentElement = (item: any): string => {
-            const serialized = JSON.stringify(item, null, 2);
-            const body = serialized === undefined ? "null" : serialized;
-            return `  ${body.replace(/\n/g, "\n  ")}`;
-        };
-
-        const writeChunk = (chunk: string): Promise<void> =>
-            new Promise<void>((res, rej) => {
-                const onErr = (err: Error) => rej(err);
-                const ok = stream.write(chunk, (err) => {
-                    if (err) {
-                        rej(err);
-                        return;
-                    }
-                    if (ok) {
-                        stream.removeListener("error", onErr);
-                        res();
-                    }
-                });
-                if (!ok) {
-                    stream.once("drain", () => {
-                        stream.removeListener("error", onErr);
-                        res();
-                    });
-                }
-                stream.once("error", onErr);
-            });
-
-        const writeChunks = async () => {
-            if (items.length === 0) {
-                stream.write("[]");
-                return;
-            }
-
-            await writeChunk("[\n");
-            for (let i = 0; i < items.length; i++) {
-                const prefix = i === 0 ? "" : ",\n";
-                await writeChunk(`${prefix}${indentElement(items[i])}`);
-            }
-            await writeChunk("\n]");
-        };
-
-        writeChunks()
-            .then(() => stream.end())
-            .catch((err) => {
-                stream.destroy();
-                fail(err as Error);
-            });
-    });
 };
 
 export const createJSAllComponentsFile = async (

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -114,6 +114,85 @@ export const createJsonFile = async (
     await fs.promises.writeFile(pathWithFilename, content, { flag: "w" });
 };
 
+/*
+ * Streams an array to disk as a pretty-printed (2-space) JSON array,
+ * one element at a time. Avoids building the whole document as a single
+ * string, which overflows V8's max string length (~512 MB) for large
+ * migration sets. Output is byte-for-byte identical to
+ * JSON.stringify(items, null, 2).
+ * */
+export const writeJsonArrayStreamed = (
+    items: any[],
+    pathWithFilename: string,
+): Promise<void> => {
+    return new Promise<void>((resolve, reject) => {
+        const stream = fs.createWriteStream(pathWithFilename, { flags: "w" });
+        let settled = false;
+
+        const fail = (err: Error) => {
+            if (settled) return;
+            settled = true;
+            reject(err);
+        };
+
+        stream.on("error", fail);
+        stream.on("finish", () => {
+            if (settled) return;
+            settled = true;
+            resolve();
+        });
+
+        const indentElement = (item: any): string => {
+            const serialized = JSON.stringify(item, null, 2);
+            const body = serialized === undefined ? "null" : serialized;
+            return `  ${body.replace(/\n/g, "\n  ")}`;
+        };
+
+        const writeChunk = (chunk: string): Promise<void> =>
+            new Promise<void>((res, rej) => {
+                const onErr = (err: Error) => rej(err);
+                const ok = stream.write(chunk, (err) => {
+                    if (err) {
+                        rej(err);
+                        return;
+                    }
+                    if (ok) {
+                        stream.removeListener("error", onErr);
+                        res();
+                    }
+                });
+                if (!ok) {
+                    stream.once("drain", () => {
+                        stream.removeListener("error", onErr);
+                        res();
+                    });
+                }
+                stream.once("error", onErr);
+            });
+
+        const writeChunks = async () => {
+            if (items.length === 0) {
+                stream.write("[]");
+                return;
+            }
+
+            await writeChunk("[\n");
+            for (let i = 0; i < items.length; i++) {
+                const prefix = i === 0 ? "" : ",\n";
+                await writeChunk(`${prefix}${indentElement(items[i])}`);
+            }
+            await writeChunk("\n]");
+        };
+
+        writeChunks()
+            .then(() => stream.end())
+            .catch((err) => {
+                stream.destroy();
+                fail(err as Error);
+            });
+    });
+};
+
 export const createJSAllComponentsFile = async (
     content: string,
     pathWithFilename: string,
@@ -237,8 +316,8 @@ export const createAndSaveToFile: CreateAndSaveToFile = async (
         const fullPath = `${sbmigWorkingDirectory}/${folder}/${finalFilename}${suffix}.${ext}`;
 
         await createDir(`${sbmigWorkingDirectory}/${folder}/`);
-        if (ext === "json") {
-            await createJsonFile(JSON.stringify(res, undefined, 2), fullPath);
+        if (Array.isArray(res)) {
+            await writeJsonArrayStreamed(res, fullPath);
         } else {
             await createJsonFile(JSON.stringify(res, undefined, 2), fullPath);
         }
@@ -249,7 +328,11 @@ export const createAndSaveToFile: CreateAndSaveToFile = async (
     if (path) {
         const folderPath = nodePath.dirname(path);
         await createDir(folderPath);
-        await createJsonFile(JSON.stringify(res, undefined, 2), path);
+        if (Array.isArray(res)) {
+            await writeJsonArrayStreamed(res, path);
+        } else {
+            await createJsonFile(JSON.stringify(res, undefined, 2), path);
+        }
 
         Logger.success(`All response written to a file:  ${path}`);
     }


### PR DESCRIPTION
## Summary

Follow-up hardening for #381.

This keeps the streamed JSON array writer for large migration artifacts, but writes to a temporary file first and only promotes it to the final artifact path after the stream completes successfully. It also verifies the serialized item count and byte count before renaming, so failed serialization or partial writes reject without leaving a partial `story-to-migrate.json` / dry-run artifact at the final path.

## Verification

- `npx eslint src/utils/files.ts __tests__/utils/files.test.ts --max-warnings=0`
- `npx vitest run __tests__/utils/files.test.ts`
- `npm run typecheck`
- `npx prettier --check src/utils/files.ts __tests__/utils/files.test.ts`
- `npm run build`
- `npm run test:unit`
