### PR TITLE
fix(migrate): stream-read large continue artifacts (ERR_STRING_TOO_LONG)

### DIFF
--- a/__tests__/utils/json-array-stream.test.ts
+++ b/__tests__/utils/json-array-stream.test.ts
@@ -1,0 +1,96 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+    readJsonArrayStreamed,
+    writeJsonArrayStreamed,
+} from "../../src/utils/files.js";
+
+let tmpDir: string;
+const file = (name: string) => path.join(tmpDir, name);
+
+const write = (name: string, content: string) => {
+    const p = file(name);
+    fs.writeFileSync(p, content);
+    return p;
+};
+
+beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sbmig-jsonstream-"));
+});
+
+afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("readJsonArrayStreamed", () => {
+    it("reads an empty array", async () => {
+        expect(await readJsonArrayStreamed(write("a.json", "[]"))).toEqual([]);
+    });
+
+    it("reads a pretty-printed array of objects", async () => {
+        const data = [{ id: 1, name: "one" }, { id: 2, name: "two" }];
+        const p = write("b.json", JSON.stringify(data, null, 2));
+        expect(await readJsonArrayStreamed(p)).toEqual(data);
+    });
+
+    it("handles strings containing structural characters and escapes", async () => {
+        const data = [
+            { text: "comma, bracket ] brace } quote \" end" },
+            { text: "back\\slash and \"quoted\"", nested: { a: [1, 2, "]"] } },
+            { text: "line\nbreak\tand unicode ✓ é 你好" },
+        ];
+        const p = write("c.json", JSON.stringify(data, null, 2));
+        expect(await readJsonArrayStreamed(p)).toEqual(data);
+    });
+
+    it("handles deeply nested objects and arrays", async () => {
+        const data = [
+            { story: { content: { body: [{ component: "x", items: [{ a: 1 }] }] } } },
+        ];
+        const p = write("d.json", JSON.stringify(data, null, 2));
+        expect(await readJsonArrayStreamed(p)).toEqual(data);
+    });
+
+    it("round-trips with writeJsonArrayStreamed", async () => {
+        const data = Array.from({ length: 50 }, (_, i) => ({
+            id: i,
+            full_slug: `stories/${i}`,
+            content: { component: "page", body: [{ component: "target", t: `, ] } " ${i}` }] },
+        }));
+        const p = file("roundtrip.json");
+        await writeJsonArrayStreamed(data, p);
+        expect(await readJsonArrayStreamed(p)).toEqual(data);
+    });
+
+    it("parses correctly across read-stream chunk boundaries (>64KB)", async () => {
+        // Default highWaterMark is 64KB; a larger file forces multiple chunks,
+        // exercising element/string boundaries that straddle chunks.
+        const data = Array.from({ length: 2000 }, (_, i) => ({
+            id: i,
+            blob: `x`.repeat(80) + `, ] } " ${i}`,
+        }));
+        const p = file("big.json");
+        await writeJsonArrayStreamed(data, p);
+        const bytes = fs.statSync(p).size;
+        expect(bytes).toBeGreaterThan(64 * 1024);
+        expect(await readJsonArrayStreamed(p)).toEqual(data);
+    });
+
+    it("rejects a file that is not a JSON array", async () => {
+        const p = write("obj.json", JSON.stringify({ not: "an array" }, null, 2));
+        await expect(readJsonArrayStreamed(p)).rejects.toThrow(
+            "Expected a JSON array",
+        );
+    });
+
+    it("rejects an empty / non-JSON file", async () => {
+        const p = write("empty.json", "   \n  ");
+        await expect(readJsonArrayStreamed(p)).rejects.toThrow(
+            "Empty or non-JSON file",
+        );
+    });
+});

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -18,6 +18,7 @@ import {
     getFilesContentWithRequire,
     listFilesInDir,
     readFile,
+    readJsonArrayStreamed,
 } from "../../utils/files.js";
 import Logger from "../../utils/logger.js";
 import { modifyOrCreateAppliedMigrationsFile } from "../../utils/migrations.js";
@@ -2369,6 +2370,20 @@ const readMigrationJson = async (
     }
 };
 
+/**
+ * Read a migration artifact that is a JSON array (e.g. the changed-items or
+ * after-full snapshots). These can exceed V8's ~512 MB max string length on
+ * large spaces, so they are streamed element by element instead of read into a
+ * single string (which would throw ERR_STRING_TOO_LONG).
+ */
+const readMigrationJsonArray = (
+    config: RequestBaseConfig,
+    filename: string,
+): Promise<any[]> =>
+    readJsonArrayStreamed(
+        `${config.sbmigWorkingDirectory}/migrations/${filename}`,
+    );
+
 export interface ContinuePlanSummary {
     manifestFileName: string;
     from: string;
@@ -2447,10 +2462,10 @@ export const prepareContinueMigration = async (
         );
     }
 
-    const changedItems = (await readMigrationJson(
+    const changedItems = await readMigrationJsonArray(
         config,
         artifacts.changedItems,
-    )) as any[];
+    );
 
     const pipelineSummary = artifacts.pipelineSummary
         ? await readMigrationJson(config, artifacts.pipelineSummary)
@@ -2487,10 +2502,7 @@ export const prepareContinueMigration = async (
         };
 
         const publishedFinalItems = artifacts.publishedAfterFull
-            ? ((await readMigrationJson(
-                  config,
-                  artifacts.publishedAfterFull,
-              )) as any[])
+            ? await readMigrationJsonArray(config, artifacts.publishedAfterFull)
             : [];
         const publishedChangedIdSet = new Set(
             (dirty.publishedChangedIds ?? []).map(String),
@@ -2507,7 +2519,7 @@ export const prepareContinueMigration = async (
     }
 
     const draftFinalItems = artifacts.draftAfterFull
-        ? ((await readMigrationJson(config, artifacts.draftAfterFull)) as any[])
+        ? await readMigrationJsonArray(config, artifacts.draftAfterFull)
         : changedItems;
 
     const pipelineResult: MigrationPipelineResult = {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -193,6 +193,149 @@ export const writeJsonArrayStreamed = (
     });
 };
 
+/*
+ * Streams a top-level JSON array from disk, parsing one element at a time.
+ * The counterpart to writeJsonArrayStreamed: large migration artifacts are
+ * written without ever building the whole document as a single string, so they
+ * must also be READ without `fs.readFile(...).toString()`, which throws
+ * ERR_STRING_TOO_LONG once the file passes V8's ~512 MB max string length.
+ *
+ * Only the array document is streamed; each individual element is parsed with
+ * JSON.parse (elements are small). Throws if the file is not a JSON array.
+ */
+export const readJsonArrayStreamed = (pathToFile: string): Promise<any[]> => {
+    return new Promise<any[]>((resolve, reject) => {
+        const stream = fs.createReadStream(resolveFromCwd(pathToFile), {
+            encoding: "utf8",
+        });
+
+        const items: any[] = [];
+        let started = false; // seen the opening `[`
+        let done = false; // seen the matching top-level `]`
+        let buffer = ""; // current element text
+        let depth = 0; // nesting depth inside the current element
+        let inString = false;
+        let escaped = false;
+        let settled = false;
+
+        const fail = (err: Error) => {
+            if (settled) return;
+            settled = true;
+            stream.destroy();
+            reject(err);
+        };
+
+        const flushElement = () => {
+            const text = buffer.trim();
+            buffer = "";
+            if (text.length === 0) {
+                return;
+            }
+            items.push(JSON.parse(text));
+        };
+
+        stream.on("data", (rawChunk: string | Buffer) => {
+            if (done) return;
+
+            // The stream is opened with utf8 encoding, so chunks arrive as
+            // strings (decoded across multi-byte boundaries). The Buffer arm is
+            // only here to satisfy the Node type signature.
+            const chunk =
+                typeof rawChunk === "string"
+                    ? rawChunk
+                    : rawChunk.toString("utf8");
+
+            for (let i = 0; i < chunk.length; i++) {
+                const ch = chunk[i]!;
+
+                if (!started) {
+                    if (ch === "[") {
+                        started = true;
+                    } else if (ch.trim() !== "") {
+                        fail(
+                            new Error(
+                                `Expected a JSON array in ${pathToFile}, found "${ch}".`,
+                            ),
+                        );
+                        return;
+                    }
+                    continue;
+                }
+
+                if (inString) {
+                    buffer += ch;
+                    if (escaped) {
+                        escaped = false;
+                    } else if (ch === "\\") {
+                        escaped = true;
+                    } else if (ch === '"') {
+                        inString = false;
+                    }
+                    continue;
+                }
+
+                if (ch === '"') {
+                    inString = true;
+                    buffer += ch;
+                    continue;
+                }
+
+                if (ch === "{" || ch === "[") {
+                    depth++;
+                    buffer += ch;
+                    continue;
+                }
+
+                if (ch === "}") {
+                    depth--;
+                    buffer += ch;
+                    continue;
+                }
+
+                if (ch === "]") {
+                    if (depth === 0) {
+                        // closing the top-level array
+                        try {
+                            flushElement();
+                        } catch (error) {
+                            fail(error as Error);
+                            return;
+                        }
+                        done = true;
+                        break;
+                    }
+                    depth--;
+                    buffer += ch;
+                    continue;
+                }
+
+                if (ch === "," && depth === 0) {
+                    try {
+                        flushElement();
+                    } catch (error) {
+                        fail(error as Error);
+                        return;
+                    }
+                    continue;
+                }
+
+                buffer += ch;
+            }
+        });
+
+        stream.on("error", fail);
+        stream.on("end", () => {
+            if (settled) return;
+            if (!started) {
+                fail(new Error(`Empty or non-JSON file: ${pathToFile}`));
+                return;
+            }
+            settled = true;
+            resolve(items);
+        });
+    });
+};
+
 export const createJSAllComponentsFile = async (
     content: string,
     pathWithFilename: string,


### PR DESCRIPTION
## Bug

`sb-mig migrate continue` crashes on large spaces:

```
Error: Cannot create a string longer than 0x1fffffe8 characters
  at Buffer.toString (node:buffer)
  at readFile (dist/utils/files.js)
  at readMigrationJson (dist/api/data-migration/component-data-migration.js)
  at prepareContinueMigration (...)
```

## Root cause

The story-array artifacts (`*-to-migrate`, `*-after-full`) are **written** with `writeJsonArrayStreamed`, so on a big space they legitimately exceed V8's ~512 MB max string length. But `continue` **read** them back with `fs.readFile().toString()` + `JSON.parse`, and `Buffer.toString()` throws `ERR_STRING_TOO_LONG` past that limit. Writing was stream-safe; reading was not.

## Fix

Add `readJsonArrayStreamed` — the read counterpart to `writeJsonArrayStreamed`. It streams the file and parses **one array element at a time** (each element is small), never materializing the whole document as a single string. `continue`'s three array reads (changed-items, draft/published after-full) now use it.

Object artifacts (manifest, pipeline-summary, dirty-published-records) are unchanged — they're written via `JSON.stringify`, so they're inherently bounded below the limit (writing would have failed otherwise).

## Tests

New `__tests__/utils/json-array-stream.test.ts` (8 cases): empty array, pretty-printed objects, strings containing `, ] } "` and escapes, deep nesting, **round-trip with `writeJsonArrayStreamed`**, **>64 KB multi-chunk** parsing (straddling read-stream chunk boundaries), and rejection of non-array / empty files.

- typecheck ✅ · build (ESM + CJS) ✅ · full suite **551 passed / 0 failed** ✅ · lint `--max-warnings=0` ✅

⚠️ Could not reproduce the literal >512 MB file locally (impractical), but the streaming parser is proven correct on the format `writeJsonArrayStreamed` emits, including multi-chunk boundaries, and it removes the single-string materialization that caused the throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)