### PR TITLE
fix(migrate): bound 'continue' memory with batched streaming writes

### DIFF
--- a/.changeset/migrate-continue-bounded-memory.md
+++ b/.changeset/migrate-continue-bounded-memory.md
@@ -1,0 +1,5 @@
+---
+"sb-mig": patch
+---
+
+Fix heap out-of-memory in `migrate continue` on large spaces: changed stories are now streamed from the dry-run artifact and written in bounded batches instead of being materialized as one in-memory array, and the full-space after-full snapshots are stream-filtered down to the dirty-published subset the dual-layer writer actually needs. Truncated artifacts (dry-run killed mid-write) now fail loudly before any write instead of silently continuing with a partial set, and preserve-layers run logs now label every write with the correct story.

--- a/__tests__/api/migration-continue.test.ts
+++ b/__tests__/api/migration-continue.test.ts
@@ -243,6 +243,103 @@ describe("migrate continue (save-only round trip)", () => {
     });
 });
 
+describe("migrate continue (bounded memory / batching)", () => {
+    const base = "batch-test";
+
+    const writeSaveOnlyArtifacts = (changedItems: unknown[]) => {
+        writeJson(`dry-run--${base}---story-to-migrate.json`, changedItems);
+        writeJson(`dry-run--${base}---story-migration-pipeline-summary.json`, {
+            totalItems: changedItems.length,
+            steps: [{ migrationConfig: "mark-target" }],
+        });
+        writeJson(`dry-run--${base}---story-continue-manifest.json`, {
+            manifestVersion: 1,
+            kind: "migrate-content-continue-manifest",
+            itemType: "story",
+            from: "space-1",
+            to: "space-1",
+            migrateFrom: "space",
+            fromFilePath: null,
+            publicationMode: "save-only",
+            migrationConfigNames: ["mark-target"],
+            publishLanguages: null,
+            resolvedPublishLanguages: null,
+            artifactBaseName: base,
+            useDatestamp: false,
+            artifacts: {
+                changedItems: `dry-run--${base}---story-to-migrate.json`,
+                pipelineSummary: `dry-run--${base}---story-migration-pipeline-summary.json`,
+                inputFull: null,
+                languageStateMap: null,
+                draftAfterFull: null,
+                publishedAfterFull: null,
+                dirtyPublishedRecords: null,
+            },
+        });
+    };
+
+    it("writes large changed sets in batches instead of one in-memory array", async () => {
+        const changedItems = Array.from({ length: 120 }, (_, index) => ({
+            story: {
+                id: `story-${index}`,
+                name: `Story ${index}`,
+                full_slug: `blog/story-${index}`,
+                content: { component: "page" },
+            },
+        }));
+        writeSaveOnlyArtifacts(changedItems);
+
+        updateStoriesMock.mockImplementation(async ({ stories }: any) =>
+            stories.map((item: any) => ({
+                status: "fulfilled",
+                value: { ok: true, stage: "update", id: item.story.id },
+            })),
+        );
+
+        const plan = await prepareContinueMigration({}, config);
+        expect(plan.summary.changedCount).toBe(120);
+
+        await plan.run();
+
+        // 120 items / batch size 50 => 3 write calls, order preserved.
+        expect(updateStoriesMock).toHaveBeenCalledTimes(3);
+        const batchSizes = updateStoriesMock.mock.calls.map(
+            ([args]: any[]) => args.stories.length,
+        );
+        expect(batchSizes).toEqual([50, 50, 20]);
+        const writtenIds = updateStoriesMock.mock.calls.flatMap(
+            ([args]: any[]) => args.stories.map((item: any) => item.story.id),
+        );
+        expect(writtenIds).toEqual(changedItems.map((item) => item.story.id));
+
+        // Run log sees the real count and per-item labels even though the
+        // changed items were never materialized as one array.
+        const runLogArgs = saveMigrationRunLogMock.mock.calls[0][0];
+        expect(runLogArgs.totalChangedItems).toBe(120);
+        expect(runLogArgs.changedItemLabels).toHaveLength(120);
+        expect(runLogArgs.changedItemLabels[119]).toEqual({
+            id: "story-119",
+            name: "Story 119",
+            slug: "blog/story-119",
+        });
+        expect(runLogArgs.pipelineResult.changedItems).toEqual([]);
+    });
+
+    it("aborts before any write when the changed-items artifact is truncated", async () => {
+        writeSaveOnlyArtifacts([]);
+        // Overwrite with a file cut off mid-element (dry-run killed mid-write).
+        fs.writeFileSync(
+            path.join(migrationsDir(), `dry-run--${base}---story-to-migrate.json`),
+            '[\n  { "story": { "id": "story-0" } },\n  { "story"',
+        );
+
+        await expect(prepareContinueMigration({}, config)).rejects.toThrow(
+            "Truncated JSON array",
+        );
+        expect(updateStoriesMock).not.toHaveBeenCalled();
+    });
+});
+
 describe("migrate continue (preserve-layers reconstruction)", () => {
     const base = "pl-test";
 
@@ -278,12 +375,36 @@ describe("migrate continue (preserve-layers reconstruction)", () => {
             },
         };
 
-        writeJson(`dry-run--${base}---story-to-migrate.json`, [draftMigrated]);
+        const storyItem = (id: string, text: string) => ({
+            story: {
+                id,
+                name: `Story ${id}`,
+                full_slug: `blog/${id}`,
+                content: {
+                    component: "page",
+                    body: [{ component: "target", text }],
+                },
+            },
+        });
+        // story-2: changed but NOT dirty-published; story-3: unchanged.
+        // Both prove that continue only keeps the dirty subset of the
+        // full-space after-full snapshots and still writes correctly.
+        const nonDirtyChanged = storyItem("story-2", "changed-non-dirty");
+        const unchanged = storyItem("story-3", "unchanged");
+
+        writeJson(`dry-run--${base}---story-to-migrate.json`, [
+            draftMigrated,
+            nonDirtyChanged,
+        ]);
         writeJson(`dry-run--${base}---draft-current-after-full.json`, [
             draftMigrated,
+            nonDirtyChanged,
+            unchanged,
         ]);
         writeJson(`dry-run--${base}---published-layer-after-full.json`, [
             publishedMigrated,
+            nonDirtyChanged,
+            unchanged,
         ]);
         writeJson(`dry-run--${base}---story-migration-pipeline-summary.json`, {
             totalItems: 1,
@@ -397,6 +518,22 @@ describe("migrate continue (preserve-layers reconstruction)", () => {
             { publish: false },
             { ...config, spaceId: "space-1" },
         );
+
+        // The non-dirty changed story goes through the regular batched write,
+        // with the dirty story filtered out of the batch.
+        expect(updateStoriesMock).toHaveBeenCalledTimes(1);
+        const [batchArgs] = updateStoriesMock.mock.calls[0];
+        expect(
+            batchArgs.stories.map((item: any) => item.story.id),
+        ).toEqual(["story-2"]);
+
+        // Run-log labels stay aligned with write order: batched non-dirty
+        // writes first, dirty dual-layer writes after.
+        const runLogArgs = saveMigrationRunLogMock.mock.calls[0][0];
+        expect(
+            runLogArgs.changedItemLabels.map((label: any) => label.id),
+        ).toEqual(["story-2", "story-1"]);
+        expect(runLogArgs.totalChangedItems).toBe(2);
     });
 });
 

--- a/__tests__/utils/json-array-stream.test.ts
+++ b/__tests__/utils/json-array-stream.test.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+    iterateJsonArrayStreamed,
     readJsonArrayStreamed,
     writeJsonArrayStreamed,
 } from "../../src/utils/files.js";
@@ -92,5 +93,46 @@ describe("readJsonArrayStreamed", () => {
         await expect(readJsonArrayStreamed(p)).rejects.toThrow(
             "Empty or non-JSON file",
         );
+    });
+
+    it("rejects a truncated array instead of returning a partial set", async () => {
+        // Simulates a dry-run killed mid-write: no closing `]`.
+        const p = write(
+            "truncated.json",
+            '[\n  { "id": 1 },\n  { "id": 2 },\n  { "id"',
+        );
+        await expect(readJsonArrayStreamed(p)).rejects.toThrow(
+            "Truncated JSON array",
+        );
+    });
+});
+
+describe("iterateJsonArrayStreamed", () => {
+    it("yields elements one at a time in file order", async () => {
+        const p = write(
+            "iterate.json",
+            JSON.stringify([{ id: 1 }, { id: 2 }, { id: 3 }], null, 2),
+        );
+
+        const seen: number[] = [];
+        for await (const item of iterateJsonArrayStreamed(p)) {
+            seen.push(item.id);
+        }
+
+        expect(seen).toEqual([1, 2, 3]);
+    });
+
+    it("throws on truncated input once the end of the file is reached", async () => {
+        const p = write("iterate-truncated.json", '[\n  { "id": 1 },\n  { "i');
+
+        const consume = async () => {
+            const seen: any[] = [];
+            for await (const item of iterateJsonArrayStreamed(p)) {
+                seen.push(item);
+            }
+            return seen;
+        };
+
+        await expect(consume()).rejects.toThrow("Truncated JSON array");
     });
 });

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -16,9 +16,9 @@ import {
     createAndSaveToFile,
     getFileContentWithRequire,
     getFilesContentWithRequire,
+    iterateJsonArrayStreamed,
     listFilesInDir,
     readFile,
-    readJsonArrayStreamed,
 } from "../../utils/files.js";
 import Logger from "../../utils/logger.js";
 import { modifyOrCreateAppliedMigrationsFile } from "../../utils/migrations.js";
@@ -1329,6 +1329,7 @@ const writeDirtyPublishedLayerStories = async (
         context,
         draftPipelineResult,
         publishedPipelineResult,
+        draftChangedIds,
         to,
         resolvedPublishLanguages,
         languagePublishStateMap,
@@ -1336,12 +1337,18 @@ const writeDirtyPublishedLayerStories = async (
         context: PublishedLayerContext;
         draftPipelineResult: MigrationPipelineResult;
         publishedPipelineResult: MigrationPipelineResult;
+        // Draft changed-membership when the changed items are streamed instead
+        // of held in draftPipelineResult.changedItems (migrate continue).
+        draftChangedIds?: Set<string>;
         to: string;
         resolvedPublishLanguages?: string[];
         languagePublishStateMap?: LanguagePublishStateMap;
     },
     config: RequestBaseConfig,
-) => {
+): Promise<{
+    results: PromiseSettledResult<any>[];
+    records: PublishedLayerRecord[];
+}> => {
     const draftFinalById = indexStoriesById(draftPipelineResult.finalItems);
     const draftChangedById = indexStoriesById(draftPipelineResult.changedItems);
     const publishedFinalById = indexStoriesById(
@@ -1350,12 +1357,14 @@ const writeDirtyPublishedLayerStories = async (
     const publishedChangedById = indexStoriesById(
         publishedPipelineResult.changedItems,
     );
+    const isDraftChanged = (id: string) =>
+        draftChangedIds ? draftChangedIds.has(id) : draftChangedById.has(id);
     const recordsToWrite = context.dirtyPublishedRecords.filter((record) => {
         const id = String(record.storyId);
-        return draftChangedById.has(id) || publishedChangedById.has(id);
+        return isDraftChanged(id) || publishedChangedById.has(id);
     });
 
-    return Promise.allSettled(
+    const results = await Promise.allSettled(
         recordsToWrite.map((record) => {
             const id = String(record.storyId);
 
@@ -1363,7 +1372,7 @@ const writeDirtyPublishedLayerStories = async (
                 {
                     record,
                     draftFinalItem: draftFinalById.get(id),
-                    draftChanged: draftChangedById.has(id),
+                    draftChanged: isDraftChanged(id),
                     publishedFinalItem: publishedFinalById.get(id),
                     publishedLayerChanged: publishedChangedById.has(id),
                     to,
@@ -1374,6 +1383,8 @@ const writeDirtyPublishedLayerStories = async (
             );
         }),
     );
+
+    return { results, records: recordsToWrite };
 };
 
 const loadItemsToMigrate = async (
@@ -1554,6 +1565,44 @@ export interface ContinueManifest {
     };
 }
 
+/**
+ * Batched supply of changed items for the write phase. `migrate continue` uses
+ * this to stream items from the dry-run artifact in bounded batches instead of
+ * materializing the whole changed set in memory (heap OOM on large spaces).
+ */
+export interface ChangedItemsSource {
+    count: number;
+    batches: () => AsyncIterable<any[]>;
+}
+
+const CONTINUE_WRITE_BATCH_SIZE = 50;
+
+async function* batchAsyncItems(
+    source: AsyncIterable<any>,
+    size: number,
+): AsyncGenerator<any[], void, undefined> {
+    let batch: any[] = [];
+    for await (const item of source) {
+        batch.push(item);
+        if (batch.length >= size) {
+            yield batch;
+            batch = [];
+        }
+    }
+    if (batch.length > 0) {
+        yield batch;
+    }
+}
+
+const labelOfChangedItem = (item: any) => {
+    const payload = item?.story || item;
+    return {
+        id: payload?.id,
+        name: payload?.name,
+        slug: payload?.full_slug || payload?.slug,
+    };
+};
+
 interface FinalizeMigrationArgs {
     itemType: "story" | "preset";
     from: string;
@@ -1572,6 +1621,8 @@ interface FinalizeMigrationArgs {
     artifactBaseName: string;
     useDatestamp: boolean;
     continuedFromManifest?: string;
+    changedItemsSource?: ChangedItemsSource;
+    draftChangedIds?: Set<string>;
 }
 
 /**
@@ -1599,6 +1650,8 @@ export const finalizeMigration = async (
         artifactBaseName,
         useDatestamp,
         continuedFromManifest,
+        changedItemsSource,
+        draftChangedIds,
     }: FinalizeMigrationArgs,
     config: RequestBaseConfig,
 ) => {
@@ -1609,95 +1662,117 @@ export const finalizeMigration = async (
         );
     }
 
+    const changedCount =
+        changedItemsSource?.count ?? pipelineResult.changedItems.length;
     const publishedLayerChangedCount =
         publishedLayerPipelineResult?.changedItems.length ?? 0;
 
-    if (
-        pipelineResult.changedItems.length === 0 &&
-        publishedLayerChangedCount === 0
-    ) {
+    if (changedCount === 0 && publishedLayerChangedCount === 0) {
         return;
     }
 
-    let writeResults: PromiseSettledResult<any>[] = [];
+    const isPreserveLayersWrite =
+        itemType === "story" &&
+        shouldUsePublishedLayerMode(publicationMode) &&
+        Boolean(publishedLayerContext);
+    const dirtyStoryIds = isPreserveLayersWrite
+        ? new Set(
+              publishedLayerContext!.dirtyPublishedRecords.map((record) =>
+                  String(record.storyId),
+              ),
+          )
+        : new Set<string>();
 
-    if (itemType === "story") {
-        if (
-            shouldUsePublishedLayerMode(publicationMode) &&
-            publishedLayerContext
-        ) {
-            const dirtyStoryIds = new Set(
-                publishedLayerContext.dirtyPublishedRecords.map((record) =>
-                    String(record.storyId),
-                ),
-            );
-            const nonDirtyChangedItems = pipelineResult.changedItems.filter(
-                (item) => !dirtyStoryIds.has(storyIdOf(item)),
-            );
-            const nonDirtyWriteResults =
-                nonDirtyChangedItems.length > 0
-                    ? await managementApi.stories.updateStories(
-                          {
-                              stories: nonDirtyChangedItems,
-                              spaceId: to,
-                              options: {
-                                  publish:
-                                      shouldPublishForPublicationMode(
-                                          publicationMode,
-                                      ),
-                                  publishLanguages: resolvedPublishLanguages,
-                                  preservePublishState:
-                                      shouldPublishForPublicationMode(
-                                          publicationMode,
-                                      ),
-                                  languagePublishStateMap,
-                              },
-                          },
-                          config,
-                      )
-                    : [];
-            const dirtyWriteResults = publishedLayerPipelineResult
-                ? await writeDirtyPublishedLayerStories(
+    // Without a source, the in-memory changed set goes through as one batch,
+    // keeping the write behavior of a regular run byte-identical.
+    const changedItemBatches: AsyncIterable<any[]> = changedItemsSource
+        ? changedItemsSource.batches()
+        : (async function* () {
+              if (pipelineResult.changedItems.length > 0) {
+                  yield pipelineResult.changedItems;
+              }
+          })();
+
+    const writeResults: PromiseSettledResult<any>[] = [];
+    const changedItemLabels: Array<{
+        id?: number | string;
+        name?: string;
+        slug?: string;
+    }> = [];
+
+    for await (const batch of changedItemBatches) {
+        const itemsToWrite = isPreserveLayersWrite
+            ? batch.filter((item) => !dirtyStoryIds.has(storyIdOf(item)))
+            : batch;
+
+        if (itemsToWrite.length === 0) {
+            continue;
+        }
+
+        const batchResults =
+            itemType === "story"
+                ? await managementApi.stories.updateStories(
                       {
-                          context: publishedLayerContext,
-                          draftPipelineResult: pipelineResult,
-                          publishedPipelineResult: publishedLayerPipelineResult,
-                          to,
-                          resolvedPublishLanguages,
-                          languagePublishStateMap,
+                          stories: itemsToWrite,
+                          spaceId: to,
+                          options: {
+                              publish:
+                                  shouldPublishForPublicationMode(
+                                      publicationMode,
+                                  ),
+                              publishLanguages: resolvedPublishLanguages,
+                              preservePublishState:
+                                  shouldPublishForPublicationMode(
+                                      publicationMode,
+                                  ),
+                              ...(isPreserveLayersWrite
+                                  ? {}
+                                  : {
+                                        publishDirtyPublishedStories:
+                                            shouldPublishDirtyDrafts(
+                                                publicationMode,
+                                            ),
+                                    }),
+                              languagePublishStateMap,
+                          },
                       },
                       config,
                   )
-                : [];
+                : await managementApi.presets.updatePresets(
+                      {
+                          presets: itemsToWrite,
+                          spaceId: to,
+                          options: {},
+                      },
+                      config,
+                  );
 
-            writeResults = [...nonDirtyWriteResults, ...dirtyWriteResults];
-        } else {
-            writeResults = await managementApi.stories.updateStories(
+        writeResults.push(...batchResults);
+        changedItemLabels.push(...itemsToWrite.map(labelOfChangedItem));
+    }
+
+    if (isPreserveLayersWrite && publishedLayerPipelineResult) {
+        const { results: dirtyWriteResults, records: dirtyWrittenRecords } =
+            await writeDirtyPublishedLayerStories(
                 {
-                    stories: pipelineResult.changedItems,
-                    spaceId: to,
-                    options: {
-                        publish:
-                            shouldPublishForPublicationMode(publicationMode),
-                        publishLanguages: resolvedPublishLanguages,
-                        preservePublishState:
-                            shouldPublishForPublicationMode(publicationMode),
-                        publishDirtyPublishedStories:
-                            shouldPublishDirtyDrafts(publicationMode),
-                        languagePublishStateMap,
-                    },
+                    context: publishedLayerContext!,
+                    draftPipelineResult: pipelineResult,
+                    publishedPipelineResult: publishedLayerPipelineResult,
+                    draftChangedIds,
+                    to,
+                    resolvedPublishLanguages,
+                    languagePublishStateMap,
                 },
                 config,
             );
-        }
-    } else if (itemType === "preset") {
-        writeResults = await managementApi.presets.updatePresets(
-            {
-                presets: pipelineResult.changedItems,
-                spaceId: to,
-                options: {},
-            },
-            config,
+
+        writeResults.push(...dirtyWriteResults);
+        changedItemLabels.push(
+            ...dirtyWrittenRecords.map((record) => ({
+                id: record.storyId,
+                name: record.name,
+                slug: record.full_slug,
+            })),
         );
     }
 
@@ -1719,6 +1794,8 @@ export const finalizeMigration = async (
                 fromFilePath,
                 languagePublishStatePath,
                 pipelineResult,
+                totalChangedItems: changedCount,
+                changedItemLabels,
                 writeResults,
                 writeSummary,
                 continuedFromManifest,
@@ -2371,16 +2448,17 @@ const readMigrationJson = async (
 };
 
 /**
- * Read a migration artifact that is a JSON array (e.g. the changed-items or
- * after-full snapshots). These can exceed V8's ~512 MB max string length on
- * large spaces, so they are streamed element by element instead of read into a
- * single string (which would throw ERR_STRING_TOO_LONG).
+ * Iterate a migration artifact that is a JSON array (e.g. the changed-items or
+ * after-full snapshots) one element at a time. These can exceed both V8's
+ * ~512 MB max string length AND the process heap on large spaces, so they are
+ * never read into a single string or materialized as one array. Callers keep
+ * only what they need per element.
  */
-const readMigrationJsonArray = (
+const iterateMigrationJsonArray = (
     config: RequestBaseConfig,
     filename: string,
-): Promise<any[]> =>
-    readJsonArrayStreamed(
+): AsyncGenerator<any, void, undefined> =>
+    iterateJsonArrayStreamed(
         `${config.sbmigWorkingDirectory}/migrations/${filename}`,
     );
 
@@ -2462,10 +2540,23 @@ export const prepareContinueMigration = async (
         );
     }
 
-    const changedItems = await readMigrationJsonArray(
+    // Counting pass: the changed-items artifact can be larger than the heap on
+    // big spaces, so it is never materialized. This pass keeps only the count
+    // and the story ids (for dirty-write membership); the items themselves are
+    // re-streamed in batches at write time. Failing here (e.g. on a truncated
+    // artifact) aborts before anything is written.
+    let changedCount = 0;
+    const changedIds = new Set<string>();
+    for await (const item of iterateMigrationJsonArray(
         config,
         artifacts.changedItems,
-    );
+    )) {
+        changedCount++;
+        const id = storyIdOf(item);
+        if (id) {
+            changedIds.add(id);
+        }
+    }
 
     const pipelineSummary = artifacts.pipelineSummary
         ? await readMigrationJson(config, artifacts.pipelineSummary)
@@ -2484,6 +2575,7 @@ export const prepareContinueMigration = async (
 
     let publishedLayerContext: PublishedLayerContext | undefined;
     let publishedLayerPipelineResult: MigrationPipelineResult | null = null;
+    const draftFinalDirtyItems: any[] = [];
 
     if (isPreserveLayers && artifacts.dirtyPublishedRecords) {
         const dirty = (await readMigrationJson(
@@ -2494,44 +2586,79 @@ export const prepareContinueMigration = async (
             publishedChangedIds: string[];
         };
 
+        const dirtyPublishedRecords = dirty.dirtyPublishedRecords ?? [];
+        const dirtyIdSet = new Set(
+            dirtyPublishedRecords.map((record) => String(record.storyId)),
+        );
+
         publishedLayerContext = {
             records: [],
             publishedLayerInputItems: [],
-            dirtyPublishedRecords: dirty.dirtyPublishedRecords ?? [],
+            dirtyPublishedRecords,
             missingPublishedLayerRecords: [],
         };
 
-        const publishedFinalItems = artifacts.publishedAfterFull
-            ? await readMigrationJsonArray(config, artifacts.publishedAfterFull)
-            : [];
+        // The after-full snapshots hold the ENTIRE space; the dual-layer
+        // writer only ever looks up dirty stories in them. Stream-filter to
+        // the dirty subset so continue never holds a full-space copy in heap.
+        const publishedFinalDirtyItems: any[] = [];
+        if (artifacts.publishedAfterFull) {
+            for await (const item of iterateMigrationJsonArray(
+                config,
+                artifacts.publishedAfterFull,
+            )) {
+                if (dirtyIdSet.has(storyIdOf(item))) {
+                    publishedFinalDirtyItems.push(item);
+                }
+            }
+        }
+
+        if (artifacts.draftAfterFull) {
+            for await (const item of iterateMigrationJsonArray(
+                config,
+                artifacts.draftAfterFull,
+            )) {
+                if (dirtyIdSet.has(storyIdOf(item))) {
+                    draftFinalDirtyItems.push(item);
+                }
+            }
+        }
+
         const publishedChangedIdSet = new Set(
             (dirty.publishedChangedIds ?? []).map(String),
         );
 
         publishedLayerPipelineResult = {
-            changedItems: publishedFinalItems.filter((item) =>
+            changedItems: publishedFinalDirtyItems.filter((item) =>
                 publishedChangedIdSet.has(storyIdOf(item)),
             ),
-            finalItems: publishedFinalItems,
+            finalItems: publishedFinalDirtyItems,
             stepReports: [],
-            totalItems: publishedFinalItems.length,
+            totalItems: publishedFinalDirtyItems.length,
         };
     }
 
-    const draftFinalItems = artifacts.draftAfterFull
-        ? await readMigrationJsonArray(config, artifacts.draftAfterFull)
-        : changedItems;
-
     const pipelineResult: MigrationPipelineResult = {
-        changedItems,
-        finalItems: draftFinalItems,
+        // Streamed in batches at write time via changedItemsSource; never
+        // materialized here.
+        changedItems: [],
+        finalItems: draftFinalDirtyItems,
         stepReports: Array.isArray(pipelineSummary?.steps)
             ? pipelineSummary.steps
             : [],
         totalItems:
             typeof pipelineSummary?.totalItems === "number"
                 ? pipelineSummary.totalItems
-                : changedItems.length,
+                : changedCount,
+    };
+
+    const changedItemsSource: ChangedItemsSource = {
+        count: changedCount,
+        batches: () =>
+            batchAsyncItems(
+                iterateMigrationJsonArray(config, artifacts.changedItems),
+                CONTINUE_WRITE_BATCH_SIZE,
+            ),
     };
 
     const resolvedPublishLanguages =
@@ -2556,7 +2683,7 @@ export const prepareContinueMigration = async (
         publicationMode: manifest.publicationMode,
         migrationConfigNames: manifest.migrationConfigNames ?? [],
         resolvedPublishLanguages: resolvedPublishLanguages ?? [],
-        changedCount: changedItems.length,
+        changedCount,
         dirtyPublishedCount:
             publishedLayerContext?.dirtyPublishedRecords.length ?? 0,
         artifactFiles,
@@ -2581,6 +2708,8 @@ export const prepareContinueMigration = async (
                 artifactBaseName: manifest.artifactBaseName,
                 useDatestamp: manifest.useDatestamp,
                 continuedFromManifest: chosen,
+                changedItemsSource,
+                draftChangedIds: changedIds,
             },
             config,
         );

--- a/src/api/data-migration/migration-run-log.ts
+++ b/src/api/data-migration/migration-run-log.ts
@@ -80,6 +80,12 @@ export interface MigrationRunLogRecord {
     error?: unknown;
 }
 
+export interface MigrationRunLogItemLabel {
+    id?: number | string;
+    name?: string;
+    slug?: string;
+}
+
 interface SaveMigrationRunLogArgs {
     artifactBaseName: string;
     useDatestamp: boolean;
@@ -94,6 +100,13 @@ interface SaveMigrationRunLogArgs {
     fromFilePath?: string;
     languagePublishStatePath?: string;
     pipelineResult: MigrationPipelineResult;
+    /**
+     * When the changed items are streamed in batches (migrate continue),
+     * pipelineResult.changedItems is intentionally empty; these carry the
+     * per-result item labels (aligned with writeResults) and the real count.
+     */
+    changedItemLabels?: MigrationRunLogItemLabel[];
+    totalChangedItems?: number;
     writeResults: PromiseSettledResult<MutationWriteResult>[];
     writeSummary: MutationWriteSummary;
     continuedFromManifest?: string;
@@ -150,6 +163,8 @@ export const buildMigrationRunLogRecords = ({
     fromFilePath,
     languagePublishStatePath,
     pipelineResult,
+    changedItemLabels,
+    totalChangedItems,
     writeResults,
     writeSummary,
     continuedFromManifest,
@@ -184,15 +199,16 @@ export const buildMigrationRunLogRecords = ({
             (step) => step.migrationConfig,
         ),
         totalItems: pipelineResult.totalItems,
-        totalChangedItems: pipelineResult.changedItems.length,
+        totalChangedItems:
+            totalChangedItems ?? pipelineResult.changedItems.length,
     } satisfies Omit<MigrationRunLogRecord, "event">;
 
     const updateRecords: MigrationRunLogRecord[] = writeResults.map(
         (result, index) => {
             const value = resolveWriteResultValue(result);
-            const changedItem = resolveChangedItemPayload(
-                pipelineResult.changedItems[index],
-            );
+            const changedItem =
+                changedItemLabels?.[index] ??
+                resolveChangedItemPayload(pipelineResult.changedItems[index]);
             const stage = value.stage || "update";
             const event: MigrationRunLogEvent = value.publishSkippedReason
                 ? "publish_skipped"

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -203,61 +203,54 @@ export const writeJsonArrayStreamed = (
  * Only the array document is streamed; each individual element is parsed with
  * JSON.parse (elements are small). Throws if the file is not a JSON array.
  */
-export const readJsonArrayStreamed = (pathToFile: string): Promise<any[]> => {
-    return new Promise<any[]>((resolve, reject) => {
-        const stream = fs.createReadStream(resolveFromCwd(pathToFile), {
-            encoding: "utf8",
-        });
+export async function* iterateJsonArrayStreamed(
+    pathToFile: string,
+): AsyncGenerator<any, void, undefined> {
+    const stream = fs.createReadStream(resolveFromCwd(pathToFile), {
+        encoding: "utf8",
+    });
 
-        const items: any[] = [];
-        let started = false; // seen the opening `[`
-        let done = false; // seen the matching top-level `]`
-        let buffer = ""; // current element text
-        let depth = 0; // nesting depth inside the current element
-        let inString = false;
-        let escaped = false;
-        let settled = false;
+    let started = false; // seen the opening `[`
+    let done = false; // seen the matching top-level `]`
+    let buffer = ""; // current element text
+    let depth = 0; // nesting depth inside the current element
+    let inString = false;
+    let escaped = false;
 
-        const fail = (err: Error) => {
-            if (settled) return;
-            settled = true;
-            stream.destroy();
-            reject(err);
-        };
+    const flushElement = (): any | undefined => {
+        const text = buffer.trim();
+        buffer = "";
+        if (text.length === 0) {
+            return undefined;
+        }
+        return JSON.parse(text);
+    };
 
-        const flushElement = () => {
-            const text = buffer.trim();
-            buffer = "";
-            if (text.length === 0) {
-                return;
-            }
-            items.push(JSON.parse(text));
-        };
-
-        stream.on("data", (rawChunk: string | Buffer) => {
-            if (done) return;
-
+    try {
+        for await (const rawChunk of stream) {
             // The stream is opened with utf8 encoding, so chunks arrive as
             // strings (decoded across multi-byte boundaries). The Buffer arm is
             // only here to satisfy the Node type signature.
             const chunk =
                 typeof rawChunk === "string"
                     ? rawChunk
-                    : rawChunk.toString("utf8");
+                    : (rawChunk as Buffer).toString("utf8");
 
             for (let i = 0; i < chunk.length; i++) {
                 const ch = chunk[i]!;
+
+                if (done) {
+                    // trailing whitespace/newlines after the closing `]`
+                    continue;
+                }
 
                 if (!started) {
                     if (ch === "[") {
                         started = true;
                     } else if (ch.trim() !== "") {
-                        fail(
-                            new Error(
-                                `Expected a JSON array in ${pathToFile}, found "${ch}".`,
-                            ),
+                        throw new Error(
+                            `Expected a JSON array in ${pathToFile}, found "${ch}".`,
                         );
-                        return;
                     }
                     continue;
                 }
@@ -295,14 +288,12 @@ export const readJsonArrayStreamed = (pathToFile: string): Promise<any[]> => {
                 if (ch === "]") {
                     if (depth === 0) {
                         // closing the top-level array
-                        try {
-                            flushElement();
-                        } catch (error) {
-                            fail(error as Error);
-                            return;
+                        const element = flushElement();
+                        if (element !== undefined) {
+                            yield element;
                         }
                         done = true;
-                        break;
+                        continue;
                     }
                     depth--;
                     buffer += ch;
@@ -310,30 +301,42 @@ export const readJsonArrayStreamed = (pathToFile: string): Promise<any[]> => {
                 }
 
                 if (ch === "," && depth === 0) {
-                    try {
-                        flushElement();
-                    } catch (error) {
-                        fail(error as Error);
-                        return;
+                    const element = flushElement();
+                    if (element !== undefined) {
+                        yield element;
                     }
                     continue;
                 }
 
                 buffer += ch;
             }
-        });
+        }
+    } finally {
+        stream.destroy();
+    }
 
-        stream.on("error", fail);
-        stream.on("end", () => {
-            if (settled) return;
-            if (!started) {
-                fail(new Error(`Empty or non-JSON file: ${pathToFile}`));
-                return;
-            }
-            settled = true;
-            resolve(items);
-        });
-    });
+    if (!started) {
+        throw new Error(`Empty or non-JSON file: ${pathToFile}`);
+    }
+
+    // A dry-run killed mid-write leaves a file without the closing `]`.
+    // Failing here (instead of returning the partial set) is what prevents a
+    // later `migrate continue` from silently writing a subset of stories.
+    if (!done) {
+        throw new Error(
+            `Truncated JSON array in ${pathToFile}: the file ends before the closing "]". The artifact was likely written by an interrupted run - re-run the dry-run.`,
+        );
+    }
+}
+
+export const readJsonArrayStreamed = async (
+    pathToFile: string,
+): Promise<any[]> => {
+    const items: any[] = [];
+    for await (const item of iterateJsonArrayStreamed(pathToFile)) {
+        items.push(item);
+    }
+    return items;
 };
 
 export const createJSAllComponentsFile = async (


### PR DESCRIPTION
## What

`migrate continue` crashed with **heap out-of-memory on large spaces**: it materialized every changed story as one in-memory array, plus — in preserve-layers mode — BOTH full-space after-full snapshots (draft + published). Parsed JS objects run 2-3× the on-disk JSON size, so an 800 MB artifact set meant several GB of heap. The earlier stream-read fix (6.4.1) removed the `ERR_STRING_TOO_LONG` crash but still collected everything into arrays.

## How

- `iterateJsonArrayStreamed` (async generator) added in `files.ts`; `readJsonArrayStreamed` is now a collector on top of it.
- `prepareContinueMigration` no longer materializes changed items: a counting pass keeps only the count + story ids, then `finalizeMigration` re-streams the artifact at write time in **batches of 50** via a new optional `changedItemsSource`. Regular (non-continue) runs pass no source and go through as a single whole-array batch — their write behavior is unchanged.
- The after-full snapshots are **stream-filtered to the dirty-published subset**, the only stories the dual-layer writer ever looks up. Continue never holds a full-space copy in heap anymore; residency is O(batch + dirty), not O(space).
- **Truncated artifacts now fail loudly.** `readJsonArrayStreamed` previously resolved with a partial set if the file ended before the closing `]` (dry-run killed mid-write) — `continue` would have silently written a subset. The counting pass hits this before any write.
- Run-log entries get explicit per-write item labels. Side-effect fix: preserve-layers run logs used to label entries by indexing the concatenated `[...nonDirty, ...dirty]` results against the *full* changed array, mislabeling everything after the first dirty story.

## Memory before/after (continue, preserve-layers)

| | before | after |
|---|---|---|
| changed stories | full array | 50-item batches |
| draft after-full | full space | dirty subset |
| published after-full | full space | dirty subset |

## Verification

- `npm run typecheck` clean, `npx vitest run` green (570 passed / 8 skipped)
- New tests: 120-item batch run (3 batched write calls, order + run-log labels + count preserved), truncated artifact aborts before any write, preserve-layers stream-filter (non-dirty changed story batched, dirty story dual-written, labels aligned), iterator + truncation coverage in `json-array-stream.test.ts`
- Existing continue/preserve-layers/run-log tests pass unchanged

## Follow-ups (not in this PR)

- `dirty-published-records` is still read/written as one JSON object (string-based); each record embeds two full stories, so a space with a *very* large dirty set could still hit limits there.
- Resume journal for crash-resume mid-continue, and consuming manifests after a successful continue (stale-manifest friction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)