### PR TITLE
feat(config): separate Delivery API rate limit from Management API

### DIFF
--- a/__tests__/api/language-publish-state.test.ts
+++ b/__tests__/api/language-publish-state.test.ts
@@ -18,6 +18,7 @@ vi.mock("storyblok-js-client", () => ({
 import {
     buildLanguagePublishStateMapFromStories,
     createStatusPreservingFetch,
+    describeDeliveryRateLimit,
 } from "../../src/api/stories/language-publish-state.js";
 
 const createStoryItem = () => ({
@@ -70,7 +71,7 @@ describe("buildLanguagePublishStateMapFromStories", () => {
             {
                 spaceId: "space-1",
                 storyblokDeliveryApiUrl: "https://api.storyblok.com/v2",
-                rateLimit: 6,
+                deliveryRateLimit: 6,
                 sbApi: {} as any,
             },
         );
@@ -106,6 +107,39 @@ describe("buildLanguagePublishStateMapFromStories", () => {
         expect(result.stories?.[
             "translation-migration-testing/test-1/contact-us"
         ].languages?.fr?.state).toBe("published_clean");
+    });
+
+    it("does not apply the Management API rate limit to the delivery client", async () => {
+        storyblokGetMock.mockResolvedValue({
+            data: {
+                story: {
+                    full_slug:
+                        "fr/translation-migration-testing/test-1/contact-us",
+                    published_at: "2026-05-20T10:00:00.000Z",
+                    content: { component: "page", body: [] },
+                },
+            },
+        });
+
+        await buildLanguagePublishStateMapFromStories(
+            {
+                from: "space-1",
+                stories: [createStoryItem()],
+                languages: ["[default]", "fr"],
+                accessToken: "preview-token",
+            },
+            {
+                spaceId: "space-1",
+                storyblokDeliveryApiUrl: "https://api.storyblok.com/v2",
+                rateLimit: 2,
+                sbApi: {} as any,
+            },
+        );
+
+        expect(storyblokClientConstructorMock).toHaveBeenCalledWith(
+            expect.objectContaining({ rateLimit: undefined }),
+            "https://api.storyblok.com/v2",
+        );
     });
 
     it("keeps 404 as a valid draft-or-unpublished signal", async () => {
@@ -307,5 +341,12 @@ describe("buildLanguagePublishStateMapFromStories", () => {
         await expect(response.json()).resolves.toEqual({
             error: "This record could not be found",
         });
+    });
+
+    it("describes an unset delivery rate limit as client-derived", () => {
+        expect(describeDeliveryRateLimit(undefined)).toBe(
+            "the rate limit storyblok-js-client derives per request (up to 50 req/s)",
+        );
+        expect(describeDeliveryRateLimit(6)).toBe("6 req/s");
     });
 });

--- a/docs/migrate-content-publish-languages.md
+++ b/docs/migrate-content-publish-languages.md
@@ -27,6 +27,8 @@ Publication is now controlled by publication-state modes, not by a generic `--pu
 
 For every selected story and every resolved language, migrate builds a language publish-state map automatically before writing. The old `--languagePublishStatePath` flow is still available as an override/debug input, but it is no longer a required separate pre-step.
 
+Building the map costs two Delivery API reads (published and draft) per story per translated language, so a large space with many languages produces tens of thousands of requests. Those reads use the `deliveryRateLimit` config option, which is separate from the Management API `rateLimit`. Leave `deliveryRateLimit` unset unless you need to throttle: `storyblok-js-client` then derives the limit per request and single-story reads run at up to 50 req/s. See `docs/security.md`.
+
 ## Storyblok API facts
 
 - Story update: `PUT /v1/spaces/:space_id/stories/:story_id`

--- a/docs/security.md
+++ b/docs/security.md
@@ -138,9 +138,9 @@ Content-Type: application/json
 
 sb-mig respects Storyblok's rate limits:
 
-- Default: 2 requests per second
-- Configurable via `rateLimit` config option
-- Uses `storyblok-js-client` built-in rate limiter
+- Management API: 2 requests per second by default, configurable via the `rateLimit` config option
+- Delivery API: configurable via the `deliveryRateLimit` config option. Leave it unset and `storyblok-js-client` derives the limit per request — it tiers CDN requests by `per_page` (up to 50 req/s for single stories) and follows the `X-RateLimit-Policy` response headers
+- Uses `storyblok-js-client` built-in rate limiter, which keeps a separate throttle queue per limit
 
 ---
 

--- a/src/api-v2/requestConfig.ts
+++ b/src/api-v2/requestConfig.ts
@@ -28,6 +28,7 @@ export function toRequestConfig(
         cacheDir: overrides?.cacheDir,
         debug: overrides?.debug,
         rateLimit: overrides?.rateLimit,
+        deliveryRateLimit: overrides?.deliveryRateLimit,
         openaiToken: overrides?.openaiToken,
         boilerplateSpaceId: overrides?.boilerplateSpaceId,
         schemaType: overrides?.schemaType,

--- a/src/api/stories/language-publish-state.ts
+++ b/src/api/stories/language-publish-state.ts
@@ -14,7 +14,6 @@ import { getAllStories, getStoryBySlug } from "./stories.js";
 
 const DEFAULT_LANGUAGE = "[default]";
 const DELIVERY_CHECK_CONCURRENCY = 5;
-const DELIVERY_API_DEFAULT_RATE_LIMIT = 5;
 const DELIVERY_API_MAX_RETRIES = 10;
 const DELIVERY_API_TIMEOUT_SECONDS = 60;
 
@@ -117,6 +116,17 @@ export const createStatusPreservingFetch =
         }
     };
 
+/**
+ * Describes the Delivery API rate limit for logging.
+ *
+ * An unset limit is not "no limit": `storyblok-js-client` then picks the limit
+ * per request from the `per_page` tier and the `X-RateLimit-Policy` headers.
+ */
+export const describeDeliveryRateLimit = (rateLimit?: number): string =>
+    rateLimit === undefined
+        ? "the rate limit storyblok-js-client derives per request (up to 50 req/s)"
+        : `${rateLimit} req/s`;
+
 const createDeliveryClient = ({
     accessToken,
     deliveryApiUrl,
@@ -129,7 +139,7 @@ const createDeliveryClient = ({
     new StoryblokClient(
         {
             accessToken,
-            rateLimit: rateLimit ?? DELIVERY_API_DEFAULT_RATE_LIMIT,
+            rateLimit,
             maxRetries: DELIVERY_API_MAX_RETRIES,
             timeout: DELIVERY_API_TIMEOUT_SECONDS,
             fetch: createStatusPreservingFetch(),
@@ -542,14 +552,14 @@ export const buildLanguagePublishStateMapFromStories = async (
         ? createDeliveryClient({
               accessToken: deliveryAccessToken,
               deliveryApiUrl,
-              rateLimit: config.rateLimit,
+              rateLimit: config.deliveryRateLimit,
           })
         : null;
     const totalDeliveryChecks = stories.length * translatedLanguages.length * 2;
 
     if (needsDeliveryApi) {
         Logger.log(
-            `Resolving translated language publish state for ${stories.length} stories and ${translatedLanguages.length} language(s). Up to ${totalDeliveryChecks} Delivery API check(s) will run through StoryblokClient at ${config.rateLimit ?? DELIVERY_API_DEFAULT_RATE_LIMIT} req/s.`,
+            `Resolving translated language publish state for ${stories.length} stories and ${translatedLanguages.length} language(s). Up to ${totalDeliveryChecks} Delivery API check(s) will run through StoryblokClient at ${describeDeliveryRateLimit(config.deliveryRateLimit)}.`,
         );
     }
 

--- a/src/config/config.types.ts
+++ b/src/config/config.types.ts
@@ -38,7 +38,19 @@ export interface IStoryblokConfig {
     flushCache: boolean;
     cacheDir: string;
     debug: boolean;
+    /**
+     * Requests per second for the Management API.
+     */
     rateLimit: number;
+    /**
+     * Requests per second for the Delivery API.
+     *
+     * Leave unset to let `storyblok-js-client` pick the limit per request: it
+     * tiers CDN requests by `per_page` (up to 50 req/s for single stories) and
+     * follows the `X-RateLimit-Policy` response headers. Set a number only to
+     * throttle below that.
+     */
+    deliveryRateLimit?: number;
     sbApi?: () => StoryblokClient;
     resolvers?: SimpleResolver[];
     advancedResolvers?: SchemaGlobalResolvers;


### PR DESCRIPTION
## Problem

`buildLanguagePublishStateMapFromStories` builds its Delivery API client from `config.rateLimit`:

```ts
const deliveryClient = createDeliveryClient({
    accessToken: deliveryAccessToken,
    deliveryApiUrl,
    rateLimit: config.rateLimit,   // <- Management API limit, default 2
})
```

`config.rateLimit` is the Management API limit (`defaultConfig.ts` sets it to `2`, matching Storyblok's stricter MAPI quota). Handing it to `StoryblokClient` as `rateLimit` sets `userRateLimit`, which sits at the top of the SDK's precedence chain (`storyblok-js-client/src/rateLimit.ts`):

```ts
function determineRateLimit(url, params, config, defaultRateLimit) {
    if (config.userRateLimit !== undefined) return Math.min(config.userRateLimit, MAX_RATE_LIMIT);
    if (config.serverHeadersRateLimit !== undefined) return Math.min(config.serverHeadersRateLimit, MAX_RATE_LIMIT);
    if (defaultRateLimit !== undefined) return defaultRateLimit;
    if (isSingleStoryRequest(url, params)) return RATE_LIMIT_TIERS.SINGLE_OR_SMALL;  // 50
    return getRateLimitTier(params.per_page);                                        // 50 / 15 / 10 / 6
}
```

So passing the MAPI limit through disables two things the SDK does on its own:

1. **Per-request CDN tiering.** The publish-state pass issues single-story `cdn/stories/<slug>` reads, which the SDK tiers at 50 req/s.
2. **Server feedback.** Without `userRateLimit`, the SDK adopts the quota it reads back from `X-RateLimit-Policy`.

Concrete impact: a space with 647 stories and 24 languages produces ~31k Delivery checks (2 per story per translated language). At 2 req/s that is over 4 hours of wall clock for reads the API would serve at 50 req/s.

`DELIVERY_API_DEFAULT_RATE_LIMIT = 5` was already dead code — `config.rateLimit` always has a value, so the `??` fallback never fired.

## Change

Split the two limits.

```ts
rateLimit: number;            // Management API (unchanged, default 2)
deliveryRateLimit?: number;   // Delivery API (new, unset by default)
```

- `rateLimit` now means Management API only.
- `deliveryRateLimit` is optional and **unset by default**, so the Delivery client passes `rateLimit: undefined` and the SDK derives the limit per request. Set a number only to throttle below that.
- `DELIVERY_API_DEFAULT_RATE_LIMIT` removed.
- The startup log line now says what it is actually doing, e.g. `... will run through StoryblokClient at the rate limit storyblok-js-client derives per request (up to 50 req/s).`

The field reaches the delivery client without new plumbing: `RequestBaseConfig extends Partial<Omit<IStoryblokConfig, "sbApi">>`, `apiConfig` is `{...storyblokConfig}`, and `buildLanguagePublishStateMap` spreads `{...config}` into `buildLanguagePublishStateMapFromStories`. Only `toRequestConfig` needed a line, since it enumerates fields explicitly.

`DELIVERY_CHECK_CONCURRENCY` (5) is untouched — it still bounds in-flight requests, and the SDK's `ThrottleQueueManager` keeps a separate throttle queue per limit, so the MAPI and Delivery queues do not contend.

### Why not a queue library

Worth recording, since it was the first instinct: adding `p-queue` here would stack a second scheduler on top of the SDK's own throttle. It would double-throttle, be blind to `X-RateLimit-Policy`, and could not reproduce the per-endpoint tiering the SDK already does. `mapWithConcurrency` already covers the concurrency side in ~25 dependency-free lines. No new dependency.

## Tests

- Existing constructor test switched to `deliveryRateLimit: 6` — documents that the Delivery client reads the Delivery knob.
- New test: with `rateLimit: 2` and no `deliveryRateLimit`, the Delivery client is constructed with `rateLimit: undefined`, i.e. the MAPI limit does not leak into Delivery.
- Unit test for the log-line helper in both states.

`npm run test:unit` 543/543 pass. `npm run typecheck` and `eslint --max-warnings=0` clean. `npm run build` clean.

## Docs

- `docs/security.md` — rate-limiting section now covers both limits and the per-limit throttle queues.
- `docs/migrate-content-publish-languages.md` — notes the request cost of building the publish-state map and which knob governs it.

## Behavior change / release type

Not a breaking API change: `deliveryRateLimit` is optional and `rateLimit` keeps its type and default. But the Delivery rate does change for existing users — publish-state runs that were implicitly throttled by `rateLimit` will now run at the SDK-derived rate. Anyone who wants the old behavior sets `deliveryRateLimit` explicitly.

Committed as `feat`, so semantic-release will cut a minor. If you would rather this land as a major given the throughput change, say so and I will add a `BREAKING CHANGE:` footer.
