### PR TITLE
feat(migrate): migrate presets parity with migrate content (DT-319)

### DIFF
--- a/__tests__/api/preset-data-migration.test.ts
+++ b/__tests__/api/preset-data-migration.test.ts
@@ -185,6 +185,53 @@ describe("preset migration pipeline (itemType: preset)", () => {
         });
     });
 
+    it("migrates only the components named by a scoped run", () => {
+        // What `migrate presets text-block --migration x` resolves to: the
+        // mapper knows both components, the scope narrows it to one.
+        const scopedMigration: PreparedMigrationConfig = {
+            migrationConfigName: "mark-both",
+            migrationConfigPath: "/test/mark-both.sb.migration.cjs",
+            migrationConfigFileContent: {
+                "text-block": (data: any) => ({
+                    wasReplaced: true,
+                    data: { ...data, migrated: true },
+                }),
+                "sb-section": (data: any) => ({
+                    wasReplaced: true,
+                    data: { ...data, migrated: true },
+                }),
+            },
+            componentsToMigrate: ["text-block"],
+            validator: null,
+        };
+
+        const result = runMigrationPipelineInMemory({
+            itemType: "preset",
+            itemsToMigrate: [
+                {
+                    id: 44,
+                    name: "Mixed preset",
+                    component_id: 15,
+                    preset: {
+                        _uid: "root",
+                        component: "sb-section",
+                        body: [
+                            { _uid: "tb", component: "text-block", text: "A" },
+                        ],
+                    },
+                },
+            ],
+            preparedMigrationConfigs: [scopedMigration],
+        });
+
+        const migratedPreset = result.finalItems[0].preset;
+        expect(migratedPreset.body[0].migrated).toBe(true);
+        expect(migratedPreset).not.toHaveProperty("migrated");
+        expect(
+            result.stepReports[0]?.replacementsByComponent,
+        ).toEqual({ "text-block": 1 });
+    });
+
     it("leaves presets without matching components unchanged", () => {
         const untouched = {
             id: 43,

--- a/__tests__/api/preset-data-migration.test.ts
+++ b/__tests__/api/preset-data-migration.test.ts
@@ -349,6 +349,104 @@ describe("preset migration write path", () => {
     });
 });
 
+describe("presets are exempt from publication machinery", () => {
+    it("normalizes an explicitly requested publication mode to save-only", async () => {
+        await doTheMigration(
+            {
+                itemType: "preset",
+                from: "space-1",
+                to: "space-1",
+                migrateFrom: "space",
+                itemsToMigrate: [createPresetItem()],
+                migrationConfigs: [markTargetMigration],
+                dryRun: true,
+                // Callers cannot pass this via the CLI, but the engine default
+                // is preserve-layers and must not leak into preset runs.
+                publicationMode: "preserve-layers",
+                publicationLanguages: "all",
+                fileName: "preset-mode-test",
+            },
+            config,
+        );
+
+        const manifest = readJson(
+            "dry-run--preset-mode-test---preset-continue-manifest.json",
+        );
+        expect(manifest.publicationMode).toBe("save-only");
+        expect(manifest.publishLanguages).toBeNull();
+        expect(resolvePublishLanguageCodesMock).not.toHaveBeenCalled();
+
+        const pipelineSummary = readJson(
+            "dry-run--preset-mode-test---preset-migration-pipeline-summary.json",
+        );
+        // The manifest now agrees with what savePipelineSummary already recorded.
+        expect(pipelineSummary.publicationMode).toBe("save-only");
+    });
+
+    it("reports progress in presets, not stories", async () => {
+        const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+        try {
+            await doTheMigration(
+                {
+                    itemType: "preset",
+                    from: "space-1",
+                    to: "space-1",
+                    migrateFrom: "space",
+                    itemsToMigrate: [createPresetItem()],
+                    migrationConfigs: [markTargetMigration],
+                    dryRun: true,
+                    fileName: "preset-progress-test",
+                },
+                config,
+            );
+
+            const output = logSpy.mock.calls.map((call) => call[0]).join("\n");
+
+            expect(output).toContain("1 preset(s) to migrate");
+            expect(output).toContain("Migration in Hero preset preset:");
+            expect(output).not.toMatch(/stories to migrate/);
+            expect(output).not.toContain("undefined");
+        } finally {
+            logSpy.mockRestore();
+        }
+    });
+
+    it("says '# No preset(s) to update #' when nothing changed", async () => {
+        const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+        try {
+            await doTheMigration(
+                {
+                    itemType: "preset",
+                    from: "space-1",
+                    to: "space-1",
+                    migrateFrom: "space",
+                    itemsToMigrate: [
+                        {
+                            id: 43,
+                            name: "Other preset",
+                            component_id: 14,
+                            preset: { _uid: "other", component: "sb-other" },
+                        },
+                    ],
+                    migrationConfigs: [markTargetMigration],
+                    dryRun: true,
+                    fileName: "preset-empty-test",
+                },
+                config,
+            );
+
+            const output = logSpy.mock.calls.map((call) => call[0]).join("\n");
+
+            expect(output).toContain("# No preset(s) to update #");
+            expect(output).not.toContain("No Stories to update");
+        } finally {
+            logSpy.mockRestore();
+        }
+    });
+});
+
 describe("preset dry-run → migrate continue", () => {
     const runPresetDryRun = () =>
         doTheMigration(
@@ -378,6 +476,10 @@ describe("preset dry-run → migrate continue", () => {
         expect(manifest.itemType).toBe("preset");
         expect(manifest.to).toBe("space-1");
         expect(manifest.migrationConfigNames).toEqual(["mark-target"]);
+        // Presets cannot be published: no publication mode, no languages.
+        expect(manifest.publicationMode).toBe("save-only");
+        expect(manifest.publishLanguages).toBeNull();
+        expect(manifest.resolvedPublishLanguages).toBeNull();
         expect(manifest.artifacts.changedItems).toBe(
             "dry-run--preset-cont-test---preset-to-migrate.json",
         );
@@ -396,6 +498,8 @@ describe("preset dry-run → migrate continue", () => {
         const plan = await prepareContinueMigration({}, config);
 
         expect(plan.summary.itemType).toBe("preset");
+        expect(plan.summary.publicationMode).toBe("save-only");
+        expect(plan.summary.resolvedPublishLanguages).toEqual([]);
         expect(plan.summary.to).toBe("space-1");
         expect(plan.summary.changedCount).toBe(1);
         expect(plan.summary.dirtyPublishedCount).toBe(0);

--- a/__tests__/api/preset-data-migration.test.ts
+++ b/__tests__/api/preset-data-migration.test.ts
@@ -60,6 +60,7 @@ import {
     runMigrationPipelineInMemory,
     type PreparedMigrationConfig,
 } from "../../src/api/data-migration/component-data-migration.js";
+import { MigrationValidationFailedError } from "../../src/api/data-migration/migration-validation.js";
 
 const markTargetMigration: PreparedMigrationConfig = {
     migrationConfigName: "mark-target",
@@ -222,6 +223,68 @@ describe("preset migration pipeline (itemType: preset)", () => {
         ).toEqual(["mark-target", "rename-target"]);
         expect(result.stepReports[0]?.touchedItems).toBe(1);
         expect(result.stepReports[1]?.touchedItems).toBe(1);
+    });
+
+    it("runs a per-step validator against the presets produced by that step", () => {
+        const seenComponents: string[] = [];
+        const recordComponent = (id: string) => ({
+            id,
+            name: id,
+            sourcePath: `/test/${id}.sb.validation.cjs`,
+            validateData: ({ data }: { data: any }) => {
+                seenComponents.push(data[0].preset.component);
+                return { ok: true, issueCount: 0, issues: [] };
+            },
+        });
+
+        const result = runMigrationPipelineInMemory({
+            itemType: "preset",
+            itemsToMigrate: [createPresetItem()],
+            preparedMigrationConfigs: [
+                { ...markTargetMigration, validator: recordComponent("after-mark") },
+                {
+                    ...renameTargetMigration,
+                    validator: recordComponent("after-rename"),
+                },
+            ],
+        });
+
+        // Each validator sees the preset state as of its own step.
+        expect(seenComponents).toEqual(["target", "target-v2"]);
+        expect(
+            result.stepReports.map((step) => step.validation?.validatorId),
+        ).toEqual(["after-mark", "after-rename"]);
+    });
+
+    it("halts the preset pipeline when a step validator fails", () => {
+        const failingValidator = {
+            id: "no-target-left",
+            name: "no-target-left",
+            sourcePath: "/test/no-target-left.sb.validation.cjs",
+            validateData: () => ({
+                ok: false,
+                issueCount: 1,
+                issues: [
+                    {
+                        componentPath: "preset",
+                        component: "target",
+                        uid: "preset-root",
+                        message: "target is not allowed",
+                    },
+                ],
+            }),
+        };
+
+        expect(() =>
+            runMigrationPipelineInMemory({
+                itemType: "preset",
+                itemsToMigrate: [createPresetItem()],
+                preparedMigrationConfigs: [
+                    { ...markTargetMigration, validator: failingValidator },
+                    renameTargetMigration,
+                ],
+            }),
+        ).toThrow(MigrationValidationFailedError);
     });
 });
 

--- a/__tests__/api/preset-data-migration.test.ts
+++ b/__tests__/api/preset-data-migration.test.ts
@@ -56,6 +56,7 @@ vi.mock("../../src/api/managementApi.js", () => ({
 
 import {
     doTheMigration,
+    migrateProvidedComponentsDataInStories,
     prepareContinueMigration,
     runMigrationPipelineInMemory,
     type PreparedMigrationConfig,
@@ -345,6 +346,58 @@ describe("preset migration write path", () => {
             config,
         );
 
+        expect(updatePresetsMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("preset pre-migration backup", () => {
+    const backupDir = () => path.join(tmpDir, "backup", "preset");
+    const listBackups = () =>
+        fs.existsSync(backupDir()) ? fs.readdirSync(backupDir()) : [];
+
+    const runFromSpace = (dryRun?: boolean) =>
+        migrateProvidedComponentsDataInStories(
+            {
+                itemType: "preset",
+                from: "space-A",
+                to: "space-A",
+                migrateFrom: "space",
+                migrationConfig: [],
+                preparedMigrationConfigs: [markTargetMigration],
+                dryRun,
+                fileName: "preset-backup-test",
+            },
+            config,
+        );
+
+    it("writes exactly one backup, of the --from space, into backup/preset", async () => {
+        getAllPresetsMock.mockResolvedValue([createPresetItem()]);
+
+        await runFromSpace();
+
+        // Presets are pulled from --from, not from the config's default space.
+        expect(getAllPresetsMock).toHaveBeenCalledTimes(1);
+        expect(getAllPresetsMock).toHaveBeenCalledWith(
+            expect.objectContaining({ spaceId: "space-A" }),
+        );
+
+        const backups = listBackups();
+        expect(backups).toHaveLength(1);
+        expect(backups[0]).toContain("preset-backup-test");
+        expect(backups[0]).toContain(".sb.presets.json");
+        expect(
+            JSON.parse(
+                fs.readFileSync(path.join(backupDir(), backups[0]!), "utf-8"),
+            ),
+        ).toEqual([createPresetItem()]);
+    });
+
+    it("writes no backup on a dry run", async () => {
+        getAllPresetsMock.mockResolvedValue([createPresetItem()]);
+
+        await runFromSpace(true);
+
+        expect(listBackups()).toHaveLength(0);
         expect(updatePresetsMock).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/api/preset-data-migration.test.ts
+++ b/__tests__/api/preset-data-migration.test.ts
@@ -1,0 +1,367 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+    modifyAppliedMigrationsMock,
+    saveMigrationRunLogMock,
+    loggerMock,
+    updatePresetsMock,
+    getAllPresetsMock,
+    updateStoriesMock,
+    resolvePublishLanguageCodesMock,
+} = vi.hoisted(() => ({
+    modifyAppliedMigrationsMock: vi.fn(),
+    saveMigrationRunLogMock: vi.fn(),
+    loggerMock: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+    updatePresetsMock: vi.fn(),
+    getAllPresetsMock: vi.fn(),
+    updateStoriesMock: vi.fn(),
+    resolvePublishLanguageCodesMock: vi.fn(),
+}));
+
+// NOTE: files.js is intentionally NOT mocked — the dry-run → continue round trip
+// relies on real disk IO (write artifacts in a temp dir, then read them back).
+vi.mock("../../src/utils/migrations.js", () => ({
+    modifyOrCreateAppliedMigrationsFile: modifyAppliedMigrationsMock,
+}));
+
+vi.mock("../../src/api/data-migration/migration-run-log.js", () => ({
+    saveMigrationRunLog: saveMigrationRunLogMock,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: loggerMock,
+}));
+
+vi.mock("../../src/api/managementApi.js", () => ({
+    managementApi: {
+        stories: {
+            updateStories: updateStoriesMock,
+            resolvePublishLanguageCodes: resolvePublishLanguageCodesMock,
+        },
+        presets: {
+            updatePresets: updatePresetsMock,
+            getAllPresets: getAllPresetsMock,
+        },
+    },
+}));
+
+import {
+    doTheMigration,
+    prepareContinueMigration,
+    runMigrationPipelineInMemory,
+    type PreparedMigrationConfig,
+} from "../../src/api/data-migration/component-data-migration.js";
+
+const markTargetMigration: PreparedMigrationConfig = {
+    migrationConfigName: "mark-target",
+    migrationConfigPath: "/test/mark-target.sb.migration.cjs",
+    migrationConfigFileContent: {
+        target: (data: any) => ({
+            wasReplaced: true,
+            data: { ...data, migrated: true },
+        }),
+    },
+    componentsToMigrate: ["target"],
+    validator: null,
+};
+
+const renameTargetMigration: PreparedMigrationConfig = {
+    migrationConfigName: "rename-target",
+    migrationConfigPath: "/test/rename-target.sb.migration.cjs",
+    migrationConfigFileContent: {
+        target: (data: any) => ({
+            wasReplaced: true,
+            data: { ...data, component: "target-v2" },
+        }),
+    },
+    componentsToMigrate: ["target"],
+    validator: null,
+};
+
+/**
+ * The raw shape `managementApi.presets.getAllPresets` returns: the preset
+ * envelope carries the metadata, `preset` carries the component data.
+ */
+const createPresetItem = () => ({
+    id: 41,
+    name: "Hero preset",
+    component_id: 12,
+    preset: {
+        _uid: "preset-root",
+        component: "target",
+        text: "Hello",
+    },
+});
+
+let tmpDir: string;
+let config: any;
+
+const migrationsDir = () => path.join(tmpDir, "migrations");
+const readJson = (file: string) =>
+    JSON.parse(fs.readFileSync(path.join(migrationsDir(), file), "utf-8"));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sbmig-presets-"));
+    fs.mkdirSync(migrationsDir(), { recursive: true });
+    config = {
+        spaceId: "space-1",
+        sbmigWorkingDirectory: tmpDir,
+        sbApi: {},
+    };
+
+    modifyAppliedMigrationsMock.mockResolvedValue(undefined);
+    saveMigrationRunLogMock.mockResolvedValue(undefined);
+    updatePresetsMock.mockResolvedValue([
+        {
+            status: "fulfilled",
+            value: { ok: true, id: 41, name: "Hero preset" },
+        },
+    ]);
+});
+
+afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("preset migration pipeline (itemType: preset)", () => {
+    it("migrates the preset data and keeps the preset envelope intact", () => {
+        const result = runMigrationPipelineInMemory({
+            itemType: "preset",
+            itemsToMigrate: [createPresetItem()],
+            preparedMigrationConfigs: [markTargetMigration],
+        });
+
+        expect(result.changedItems).toHaveLength(1);
+        expect(result.totalItems).toBe(1);
+        expect(result.finalItems[0]).toEqual({
+            id: 41,
+            name: "Hero preset",
+            component_id: 12,
+            preset: {
+                _uid: "preset-root",
+                component: "target",
+                text: "Hello",
+                migrated: true,
+            },
+        });
+    });
+
+    it("migrates components nested inside the preset data", () => {
+        const nestedPreset = {
+            id: 42,
+            name: "Section preset",
+            component_id: 13,
+            preset: {
+                _uid: "section-root",
+                component: "sb-section",
+                body: [{ _uid: "child-1", component: "target", text: "Nested" }],
+            },
+        };
+
+        const result = runMigrationPipelineInMemory({
+            itemType: "preset",
+            itemsToMigrate: [nestedPreset],
+            preparedMigrationConfigs: [markTargetMigration],
+        });
+
+        expect(result.changedItems).toHaveLength(1);
+        expect(result.finalItems[0].preset.body[0]).toEqual({
+            _uid: "child-1",
+            component: "target",
+            text: "Nested",
+            migrated: true,
+        });
+    });
+
+    it("leaves presets without matching components unchanged", () => {
+        const untouched = {
+            id: 43,
+            name: "Other preset",
+            component_id: 14,
+            preset: { _uid: "other-root", component: "sb-other", text: "Keep" },
+        };
+
+        const result = runMigrationPipelineInMemory({
+            itemType: "preset",
+            itemsToMigrate: [untouched],
+            preparedMigrationConfigs: [markTargetMigration],
+        });
+
+        expect(result.changedItems).toHaveLength(0);
+        expect(result.finalItems[0]).toEqual(untouched);
+    });
+
+    it("runs a multi-step preset pipeline in order with per-step reports", () => {
+        const result = runMigrationPipelineInMemory({
+            itemType: "preset",
+            itemsToMigrate: [createPresetItem()],
+            preparedMigrationConfigs: [
+                markTargetMigration,
+                renameTargetMigration,
+            ],
+        });
+
+        expect(result.finalItems[0].preset).toEqual({
+            _uid: "preset-root",
+            component: "target-v2",
+            text: "Hello",
+            migrated: true,
+        });
+        expect(
+            result.stepReports.map((step) => step.migrationConfig),
+        ).toEqual(["mark-target", "rename-target"]);
+        expect(result.stepReports[0]?.touchedItems).toBe(1);
+        expect(result.stepReports[1]?.touchedItems).toBe(1);
+    });
+});
+
+describe("preset migration write path", () => {
+    it("writes changed presets through presets.updatePresets with no publish options", async () => {
+        await doTheMigration(
+            {
+                itemType: "preset",
+                from: "space-1",
+                to: "space-1",
+                migrateFrom: "space",
+                itemsToMigrate: [createPresetItem()],
+                migrationConfigs: [markTargetMigration],
+                fileName: "preset-write-test",
+            },
+            config,
+        );
+
+        expect(updatePresetsMock).toHaveBeenCalledTimes(1);
+        const [updateArgs] = updatePresetsMock.mock.calls[0];
+        expect(updateArgs.spaceId).toBe("space-1");
+        expect(updateArgs.options).toEqual({});
+        expect(updateArgs.presets).toHaveLength(1);
+        expect(updateArgs.presets[0]).toMatchObject({
+            id: 41,
+            name: "Hero preset",
+            preset: { component: "target", migrated: true },
+        });
+
+        // Presets are exempt from every piece of story publication machinery.
+        expect(updateStoriesMock).not.toHaveBeenCalled();
+        expect(resolvePublishLanguageCodesMock).not.toHaveBeenCalled();
+
+        expect(modifyAppliedMigrationsMock).toHaveBeenCalledWith(
+            "mark-target",
+            "preset",
+        );
+    });
+
+    it("writes nothing when no preset changed", async () => {
+        await doTheMigration(
+            {
+                itemType: "preset",
+                from: "space-1",
+                to: "space-1",
+                migrateFrom: "space",
+                itemsToMigrate: [
+                    {
+                        id: 43,
+                        name: "Other preset",
+                        component_id: 14,
+                        preset: { _uid: "other", component: "sb-other" },
+                    },
+                ],
+                migrationConfigs: [markTargetMigration],
+                fileName: "preset-noop-test",
+            },
+            config,
+        );
+
+        expect(updatePresetsMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("preset dry-run → migrate continue", () => {
+    const runPresetDryRun = () =>
+        doTheMigration(
+            {
+                itemType: "preset",
+                from: "space-1",
+                to: "space-1",
+                migrateFrom: "space",
+                itemsToMigrate: [createPresetItem()],
+                migrationConfigs: [markTargetMigration],
+                dryRun: true,
+                fileName: "preset-cont-test",
+            },
+            config,
+        );
+
+    it("dry-run writes a preset continue manifest pointing at the real artifacts", async () => {
+        await runPresetDryRun();
+
+        expect(updatePresetsMock).not.toHaveBeenCalled();
+
+        const manifest = readJson(
+            "dry-run--preset-cont-test---preset-continue-manifest.json",
+        );
+        expect(manifest.kind).toBe("migrate-content-continue-manifest");
+        expect(manifest.manifestVersion).toBe(1);
+        expect(manifest.itemType).toBe("preset");
+        expect(manifest.to).toBe("space-1");
+        expect(manifest.migrationConfigNames).toEqual(["mark-target"]);
+        expect(manifest.artifacts.changedItems).toBe(
+            "dry-run--preset-cont-test---preset-to-migrate.json",
+        );
+        expect(manifest.artifacts.pipelineSummary).toBe(
+            "dry-run--preset-cont-test---preset-migration-pipeline-summary.json",
+        );
+        // Presets have no draft/published layers.
+        expect(manifest.artifacts.draftAfterFull).toBeNull();
+        expect(manifest.artifacts.publishedAfterFull).toBeNull();
+        expect(manifest.artifacts.dirtyPublishedRecords).toBeNull();
+    });
+
+    it("continue replays the migrated presets to Storyblok without re-pulling", async () => {
+        await runPresetDryRun();
+
+        const plan = await prepareContinueMigration({}, config);
+
+        expect(plan.summary.itemType).toBe("preset");
+        expect(plan.summary.to).toBe("space-1");
+        expect(plan.summary.changedCount).toBe(1);
+        expect(plan.summary.dirtyPublishedCount).toBe(0);
+        expect(plan.summary.migrationConfigNames).toEqual(["mark-target"]);
+        expect(updatePresetsMock).not.toHaveBeenCalled();
+        expect(getAllPresetsMock).not.toHaveBeenCalled();
+
+        await plan.run();
+
+        // The exact same write a real migrate-presets run would make.
+        expect(updatePresetsMock).toHaveBeenCalledTimes(1);
+        const [updateArgs] = updatePresetsMock.mock.calls[0];
+        expect(updateArgs.spaceId).toBe("space-1");
+        expect(updateArgs.options).toEqual({});
+        expect(updateArgs.presets).toHaveLength(1);
+        expect(updateArgs.presets[0]).toMatchObject({
+            id: 41,
+            name: "Hero preset",
+            preset: { component: "target", migrated: true },
+        });
+
+        expect(modifyAppliedMigrationsMock).toHaveBeenCalledWith(
+            "mark-target",
+            "preset",
+        );
+
+        const runLogArgs = saveMigrationRunLogMock.mock.calls[0][0];
+        expect(runLogArgs.continuedFromManifest).toBe(
+            "dry-run--preset-cont-test---preset-continue-manifest.json",
+        );
+    });
+});

--- a/__tests__/cli/migrate-presets.test.ts
+++ b/__tests__/cli/migrate-presets.test.ts
@@ -55,6 +55,7 @@ const runMigratePresets = (flags: Record<string, unknown>) =>
 beforeEach(() => {
     vi.clearAllMocks();
     mocks.migrateAllComponentsDataInStories.mockResolvedValue(undefined);
+    mocks.migrateProvidedComponentsDataInStories.mockResolvedValue(undefined);
     mocks.getAllPresets.mockResolvedValue([]);
     mocks.createAndSaveToFile.mockResolvedValue(undefined);
 });
@@ -109,6 +110,87 @@ describe("migrate presets --migration pipeline", () => {
         ).rejects.toThrow("Pass at least one --migration value");
 
         expect(mocks.migrateAllComponentsDataInStories).not.toHaveBeenCalled();
+    });
+});
+
+describe("migrate presets <component...> (scoped run)", () => {
+    const runScoped = (components: string[], flags: Record<string, unknown>) =>
+        migrate({
+            input: ["migrate", "presets", ...components],
+            flags,
+        } as any);
+
+    it("scopes the migration to the provided component names", async () => {
+        await runScoped(["text-block", "sb-section"], {
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            dryRun: true,
+        });
+
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).toHaveBeenCalledTimes(1);
+        const [engineArgs] =
+            mocks.migrateProvidedComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.itemType).toBe("preset");
+        expect(engineArgs.componentsToMigrate).toEqual([
+            "text-block",
+            "sb-section",
+        ]);
+        expect(engineArgs.migrationConfig).toEqual(["migration-a"]);
+        expect(engineArgs.from).toBe("12345");
+        expect(engineArgs.to).toBe("12345");
+        // Mirrors the stories scoped path: always a space run.
+        expect(engineArgs.migrateFrom).toBe("space");
+        expect(mocks.migrateAllComponentsDataInStories).not.toHaveBeenCalled();
+    });
+
+    it("supports multiple --migration values in a scoped run", async () => {
+        await runScoped(["text-block"], {
+            from: "12345",
+            to: "12345",
+            migration: ["migration-a", "migration-b"],
+            dryRun: true,
+        });
+
+        const [engineArgs] =
+            mocks.migrateProvidedComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.migrationConfig).toEqual([
+            "migration-a",
+            "migration-b",
+        ]);
+    });
+
+    it("falls back to the migration's own component scope when none is named", async () => {
+        await runScoped([], {
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            dryRun: true,
+        });
+
+        const [engineArgs] =
+            mocks.migrateProvidedComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.componentsToMigrate).toEqual([]);
+    });
+
+    it("still routes --all through the all-components path", async () => {
+        await runScoped([], {
+            all: true,
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            dryRun: true,
+        });
+
+        expect(mocks.migrateAllComponentsDataInStories).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).not.toHaveBeenCalled();
     });
 });
 

--- a/__tests__/cli/migrate-presets.test.ts
+++ b/__tests__/cli/migrate-presets.test.ts
@@ -112,6 +112,59 @@ describe("migrate presets --migration pipeline", () => {
     });
 });
 
+describe("migrate presets backup", () => {
+    it("does not run its own backup on a real space run — the engine owns it", async () => {
+        await runMigratePresets({
+            all: true,
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            yes: true,
+        });
+
+        expect(mocks.migrateAllComponentsDataInStories).toHaveBeenCalledTimes(
+            1,
+        );
+        const [engineArgs] =
+            mocks.migrateAllComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.from).toBe("12345");
+
+        // The old CLI-level backup pulled from apiConfig's default space and
+        // wrote a second "presets-backup" file.
+        expect(mocks.getAllPresets).not.toHaveBeenCalled();
+        expect(mocks.createAndSaveToFile).not.toHaveBeenCalled();
+    });
+
+    it("hits no API on a --migrate-from file run", async () => {
+        await runMigratePresets({
+            all: true,
+            migrateFrom: "file",
+            fromFilePath: "sbmig/presets/presets-backup.json",
+            to: "12345",
+            migration: "migration-a",
+            yes: true,
+        });
+
+        expect(mocks.getAllPresets).not.toHaveBeenCalled();
+        expect(mocks.createAndSaveToFile).not.toHaveBeenCalled();
+    });
+
+    it("hits no API on a dry run", async () => {
+        await runMigratePresets({
+            all: true,
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            dryRun: true,
+        });
+
+        expect(mocks.getAllPresets).not.toHaveBeenCalled();
+        expect(mocks.createAndSaveToFile).not.toHaveBeenCalled();
+    });
+});
+
 describe("migrate presets publication flags", () => {
     it.each([
         ["publicationMode", "save-only"],

--- a/__tests__/cli/migrate-presets.test.ts
+++ b/__tests__/cli/migrate-presets.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    migrateAllComponentsDataInStories: vi.fn(),
+    migrateProvidedComponentsDataInStories: vi.fn(),
+    prepareContinueMigration: vi.fn(),
+    getAllPresets: vi.fn(),
+    createAndSaveToFile: vi.fn(),
+}));
+
+vi.mock("../../src/cli/api-config.js", () => ({
+    apiConfig: {
+        spaceId: "default-space",
+        sbApi: {},
+    },
+}));
+
+vi.mock("../../src/api/data-migration/component-data-migration.js", () => ({
+    migrateAllComponentsDataInStories:
+        mocks.migrateAllComponentsDataInStories,
+    migrateProvidedComponentsDataInStories:
+        mocks.migrateProvidedComponentsDataInStories,
+    prepareContinueMigration: mocks.prepareContinueMigration,
+}));
+
+vi.mock("../../src/api/managementApi.js", () => ({
+    managementApi: {
+        presets: {
+            getAllPresets: mocks.getAllPresets,
+        },
+    },
+}));
+
+vi.mock("../../src/utils/files.js", () => ({
+    createAndSaveToFile: mocks.createAndSaveToFile,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+import { migrate } from "../../src/cli/commands/migrate.js";
+
+const runMigratePresets = (flags: Record<string, unknown>) =>
+    migrate({
+        input: ["migrate", "presets"],
+        flags,
+    } as any);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.migrateAllComponentsDataInStories.mockResolvedValue(undefined);
+    mocks.getAllPresets.mockResolvedValue([]);
+    mocks.createAndSaveToFile.mockResolvedValue(undefined);
+});
+
+describe("migrate presets --migration pipeline", () => {
+    it("passes every --migration value to the engine, in order", async () => {
+        await runMigratePresets({
+            all: true,
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: ["migration-a", "migration-b"],
+            dryRun: true,
+        });
+
+        expect(mocks.migrateAllComponentsDataInStories).toHaveBeenCalledTimes(
+            1,
+        );
+        const [engineArgs] =
+            mocks.migrateAllComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.itemType).toBe("preset");
+        expect(engineArgs.migrationConfig).toEqual([
+            "migration-a",
+            "migration-b",
+        ]);
+    });
+
+    it("still passes a single --migration value as a one-step pipeline", async () => {
+        await runMigratePresets({
+            all: true,
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            dryRun: true,
+        });
+
+        const [engineArgs] =
+            mocks.migrateAllComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.migrationConfig).toEqual(["migration-a"]);
+    });
+
+    it("requires at least one --migration value", async () => {
+        await expect(
+            runMigratePresets({
+                all: true,
+                migrateFrom: "space",
+                from: "12345",
+                to: "12345",
+                dryRun: true,
+            }),
+        ).rejects.toThrow("Pass at least one --migration value");
+
+        expect(mocks.migrateAllComponentsDataInStories).not.toHaveBeenCalled();
+    });
+});
+
+describe("migrate presets publication flags", () => {
+    it.each([
+        ["publicationMode", "save-only"],
+        ["publicationLanguages", "default"],
+        ["languagePublishStatePath", "sbmig/state.json"],
+    ])("rejects --%s", async (flag, value) => {
+        await expect(
+            runMigratePresets({
+                all: true,
+                migrateFrom: "space",
+                from: "12345",
+                to: "12345",
+                migration: "migration-a",
+                dryRun: true,
+                [flag]: value,
+            }),
+        ).rejects.toThrow("only supported for 'migrate content'");
+
+        expect(mocks.migrateAllComponentsDataInStories).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/cli/migrate-presets.test.ts
+++ b/__tests__/cli/migrate-presets.test.ts
@@ -247,6 +247,90 @@ describe("migrate presets backup", () => {
     });
 });
 
+describe("migrate presets cross-space guard", () => {
+    it("fails fast when --from and --to are different spaces", async () => {
+        await expect(
+            runMigratePresets({
+                all: true,
+                migrateFrom: "space",
+                from: "12345",
+                to: "67890",
+                migration: "migration-a",
+                yes: true,
+            }),
+        ).rejects.toThrow(
+            "requires --from and --to to be the same Storyblok space (got 12345 → 67890)",
+        );
+
+        expect(mocks.migrateAllComponentsDataInStories).not.toHaveBeenCalled();
+    });
+
+    it("fails fast on a cross-space scoped run too", async () => {
+        await expect(
+            migrate({
+                input: ["migrate", "presets", "text-block"],
+                flags: {
+                    from: "12345",
+                    to: "67890",
+                    migration: "migration-a",
+                    yes: true,
+                },
+            } as any),
+        ).rejects.toThrow("the same Storyblok space");
+
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).not.toHaveBeenCalled();
+    });
+
+    it("guards dry runs as well, so the plan is never misleading", async () => {
+        await expect(
+            runMigratePresets({
+                all: true,
+                migrateFrom: "space",
+                from: "12345",
+                to: "67890",
+                migration: "migration-a",
+                dryRun: true,
+            }),
+        ).rejects.toThrow("the same Storyblok space");
+    });
+
+    it("leaves same-space runs alone", async () => {
+        await runMigratePresets({
+            all: true,
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: "migration-a",
+            yes: true,
+        });
+
+        expect(mocks.migrateAllComponentsDataInStories).toHaveBeenCalledTimes(
+            1,
+        );
+    });
+
+    it("does not block --migrate-from file runs, where 'from' is a file name", async () => {
+        await runMigratePresets({
+            all: true,
+            migrateFrom: "file",
+            fromFilePath: "sbmig/presets/presets-backup.json",
+            to: "12345",
+            migration: "migration-a",
+            yes: true,
+        });
+
+        expect(mocks.migrateAllComponentsDataInStories).toHaveBeenCalledTimes(
+            1,
+        );
+        const [engineArgs] =
+            mocks.migrateAllComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.from).toBe("presets-backup");
+        expect(engineArgs.to).toBe("12345");
+    });
+});
+
 describe("migrate presets publication flags", () => {
     it.each([
         ["publicationMode", "save-only"],

--- a/src/api/data-migration/component-data-migration.ts
+++ b/src/api/data-migration/component-data-migration.ts
@@ -472,8 +472,8 @@ const applySingleMigrationToItems = ({
                 `Migration in ${chalk.magenta(
                     itemType === "story"
                         ? item[itemType]?.full_slug
-                        : item[itemType]?.name,
-                )} page: `,
+                        : item.name,
+                )} ${itemType === "story" ? "page" : "preset"}: `,
             );
             preparedMigrationConfig.componentsToMigrate.forEach(
                 (component: string) => {
@@ -1952,7 +1952,7 @@ export const doTheMigration = async (
         migrationConfigs,
         to,
         dryRun,
-        publicationMode = DEFAULT_PUBLICATION_MODE,
+        publicationMode: requestedPublicationMode = DEFAULT_PUBLICATION_MODE,
         publicationLanguages,
         migrateFrom,
         fromFilePath,
@@ -1982,6 +1982,11 @@ export const doTheMigration = async (
         });
     const artifactBaseName = resolveOutputFileBaseName({ from, fileName });
     const useDatestamp = shouldUseDatestampForArtifacts(fileName);
+    // Presets have no draft/published layers and no per-language publish state,
+    // so they are exempt from all publication machinery. Normalizing here keeps
+    // the continue manifest and `migrate continue` summary honest.
+    const publicationMode: PublicationMode =
+        itemType === "preset" ? "save-only" : requestedPublicationMode;
     const effectivePublicationLanguages =
         publicationMode === "save-only"
             ? undefined
@@ -2073,9 +2078,11 @@ export const doTheMigration = async (
     }
 
     if (pipelineResult.changedItems.length === 0) {
-        console.log("# No Stories to update #");
+        console.log(`# No ${itemType}(s) to update #`);
     } else {
-        console.log(`${pipelineResult.changedItems.length} stories to migrate`);
+        console.log(
+            `${pipelineResult.changedItems.length} ${itemType}(s) to migrate`,
+        );
     }
 
     if (

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -313,6 +313,7 @@ export const migrateDescription = `
     USAGE
         $ sb-mig migrate content [component-name ...] --from [spaceId] --to [spaceId] --migration [migration-config]
         $ sb-mig migrate content --all --from [spaceId] --to [spaceId] --migration [migration-config]
+        $ sb-mig migrate presets [component-name ...] --from [spaceId] --to [spaceId] --migration [migration-config]
         $ sb-mig migrate presets --all --from [spaceId-or-file] --to [spaceId] --migration [migration-config]
 
     DESCRIPTION
@@ -321,7 +322,7 @@ export const migrateDescription = `
 
     COMMANDS
         content         Migrate story content for all components or provided component names.
-        presets         Migrate presets. Supports --all.
+        presets         Migrate preset data for all components or provided component names.
         continue        Finish a previous --dry-run by writing its already-computed result to
                         Storyblok. Skips pulling stories and re-running the migration, so it is
                         much faster. Requires a content freeze between the dry-run and continue.
@@ -382,6 +383,8 @@ export const migrateDescription = `
         $ sb-mig migrate presets --all --from 12345 --to 12345 --migration preset-migration --dry-run
         $ sb-mig migrate presets --all --from 12345 --to 12345 --migration migration-a --migration migration-b --yes
         $ sb-mig migrate presets --all --migrate-from file --fromFilePath sbmig/presets/presets-backup.json --to 12345 --migration preset-migration
+        $ sb-mig migrate presets text-block --from 12345 --to 12345 --migration preset-migration
+        $ sb-mig migrate presets text-block sb-section --from 12345 --to 12345 --migration preset-migration --dry-run
 `;
 
 export const revertDescription = `

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -354,7 +354,8 @@ export const migrateDescription = `
         content creates a story backup before provided-component migrations unless --dry-run is passed.
         content --dry-run also writes a continue manifest so the run can later be finished with migrate continue.
         continue writes the dry-run's migrated stories to Storyblok and updates applied-backpack-migrations.json. It does not pull or re-transform stories.
-        presets backs up all remote presets before writing migrated presets unless --dry-run is passed.
+        presets writes migrated presets to Storyblok unless --dry-run is passed.
+        presets backs up the --from space's presets into backup/preset before writing, unless --dry-run or --migrate-from file is used.
 
     GOTCHAS
         At least one --migration value is required.

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -321,7 +321,7 @@ export const migrateDescription = `
 
     COMMANDS
         content         Migrate story content for all components or provided component names.
-        presets         Migrate presets. Supports --all and exactly one --migration value.
+        presets         Migrate presets. Supports --all.
         continue        Finish a previous --dry-run by writing its already-computed result to
                         Storyblok. Skips pulling stories and re-running the migration, so it is
                         much faster. Requires a content freeze between the dry-run and continue.
@@ -333,7 +333,7 @@ export const migrateDescription = `
         --fromFilePath    Direct path to stories or presets JSON when using --migrate-from file.
         --to              Target Storyblok space ID.
         --migrate-from    Migrate from space or file. Default: space.
-        --migration       Migration file name without extension. Can be repeated for ordered content pipelines. Presets support exactly one.
+        --migration       Migration file name without extension. Can be repeated for ordered migration pipelines.
         --migrationComponentAlias
                           Add extra component aliases for a migration. Repeatable. Format: <migration>:<source>=<alias1>,<alias2>.
         --migrationComponents
@@ -379,6 +379,7 @@ export const migrateDescription = `
         $ sb-mig migrate content --all --migrate-from file --fromFilePath sbmig/migrations/dry-run--123---story-to-migrate.json --to 12345 --migration migration-a --migration migration-b
         $ sb-mig migrate content my-component-1 my-component-2 --from 12345 --to 12345 --migration file-with-migration
         $ sb-mig migrate presets --all --from 12345 --to 12345 --migration preset-migration --dry-run
+        $ sb-mig migrate presets --all --from 12345 --to 12345 --migration migration-a --migration migration-b --yes
         $ sb-mig migrate presets --all --migrate-from file --fromFilePath sbmig/presets/presets-backup.json --to 12345 --migration preset-migration
 `;
 

--- a/src/cli/cli-descriptions.ts
+++ b/src/cli/cli-descriptions.ts
@@ -361,6 +361,7 @@ export const migrateDescription = `
     GOTCHAS
         At least one --migration value is required.
         preserve-layers currently requires --migrate-from space and requires --from and --to to be the same Storyblok space.
+        presets --migrate-from space requires --from and --to to be the same Storyblok space: preset writes reuse the source preset IDs.
         --publicationLanguages cannot be used with --publicationMode save-only.
         --languagePublishStatePath cannot be used with --publicationMode save-only.
         --publicationMode, --publicationLanguages, and --languagePublishStatePath are only supported for migrate content, not migrate presets.

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -88,6 +88,30 @@ const assertNoLegacyPublicationFlags = (flags: Record<string, unknown>) => {
     }
 };
 
+/**
+ * Preset writes PUT to `spaces/<to>/presets/<id>` reusing the id the preset
+ * has in the source space. Across spaces those ids either do not exist or
+ * belong to unrelated presets, so a cross-space run is rejected until preset
+ * id remapping is deliberately designed.
+ *
+ * File runs are exempt: there `from` is a file name, not a space.
+ */
+const assertSameSpaceForPresets = ({
+    migrateFrom,
+    from,
+    to,
+}: {
+    migrateFrom: MigrateFrom;
+    from: string;
+    to: string;
+}) => {
+    if (migrateFrom === "space" && from !== to) {
+        throw new Error(
+            `'migrate presets' requires --from and --to to be the same Storyblok space (got ${from} → ${to}). Preset writes reuse the source preset IDs, which do not exist in another space.`,
+        );
+    }
+};
+
 export const migrate = async (props: CLIOptions) => {
     const { input, flags } = props;
 
@@ -408,6 +432,8 @@ export const migrate = async (props: CLIOptions) => {
 
                 const migrateFrom: MigrateFrom = "space";
 
+                assertSameSpaceForPresets({ migrateFrom, from, to });
+
                 const runMigration = async () => {
                     Logger.warning("Preparing to migrate...");
 
@@ -447,6 +473,8 @@ export const migrate = async (props: CLIOptions) => {
                 }
             } else if (isIt("all")) {
                 const migrateFrom: MigrateFrom = flags["migrateFrom"];
+
+                assertSameSpaceForPresets({ migrateFrom, from, to });
 
                 const runMigration = async () => {
                     Logger.warning("Preparing to migrate...");

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -374,6 +374,8 @@ export const migrate = async (props: CLIOptions) => {
             const languagePublishStatePath = flags[
                 "languagePublishStatePath"
             ] as string | undefined;
+            const dryRun = flags["dryRun"] as boolean | undefined;
+            const fileName = flags["fileName"] as string | undefined;
 
             if (migrationConfigs.length === 0) {
                 throw new Error(
@@ -401,10 +403,50 @@ export const migrate = async (props: CLIOptions) => {
 
             console.log("Migrating with presets");
 
-            if (isIt("all")) {
+            if (isIt("empty")) {
+                const componentsToMigrate = unpackElements(input) || [""];
+
+                const migrateFrom: MigrateFrom = "space";
+
+                const runMigration = async () => {
+                    Logger.warning("Preparing to migrate...");
+
+                    // The pre-migration backup is made by the engine, which
+                    // backs up the actual `from` items into backup/preset.
+                    await migrateProvidedComponentsDataInStories(
+                        {
+                            itemType: "preset",
+                            from,
+                            to,
+                            migrateFrom,
+                            componentsToMigrate,
+                            migrationConfig: migrationConfigs,
+                            migrationComponentAliases,
+                            migrationComponentOverrides,
+                            dryRun,
+                            fromFilePath,
+                            fileName,
+                        },
+                        apiConfig,
+                    );
+                };
+
+                if (dryRun) {
+                    await runMigration();
+                } else {
+                    await askForConfirmation(
+                        "Are you sure you want to MIGRATE presets in your space ? (it will overwrite them)",
+                        runMigration,
+                        () => {
+                            Logger.warning(
+                                "Migration not started, exiting the program...",
+                            );
+                        },
+                        flags["yes"],
+                    );
+                }
+            } else if (isIt("all")) {
                 const migrateFrom: MigrateFrom = flags["migrateFrom"];
-                const dryRun = flags["dryRun"] as boolean | undefined;
-                const fileName = flags["fileName"] as string | undefined;
 
                 const runMigration = async () => {
                     Logger.warning("Preparing to migrate...");

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -379,7 +379,7 @@ export const migrate = async (props: CLIOptions) => {
 
             if (migrationConfigs.length === 0) {
                 throw new Error(
-                    "Missing migration config. Pass exactly one --migration value for presets.",
+                    "Missing migration config. Pass at least one --migration value.",
                 );
             }
 
@@ -398,12 +398,6 @@ export const migrate = async (props: CLIOptions) => {
             if (languagePublishStatePath) {
                 throw new Error(
                     "--languagePublishStatePath is only supported for 'migrate content'. Presets cannot be published.",
-                );
-            }
-
-            if (migrationConfigs.length > 1) {
-                throw new Error(
-                    "Multiple --migration values are currently supported only for 'migrate content'. Presets support a single migration config.",
                 );
             }
 
@@ -438,7 +432,7 @@ export const migrate = async (props: CLIOptions) => {
                             from,
                             to,
                             migrateFrom,
-                            migrationConfig: migrationConfigs[0] as string,
+                            migrationConfig: migrationConfigs,
                             migrationComponentAliases,
                             migrationComponentOverrides,
                             dryRun,

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -16,10 +16,8 @@ import {
     parseMigrationComponentAliasFlags,
     parseMigrationComponentOverrideFlags,
 } from "../../api/data-migration/migration-component-scope.js";
-import { managementApi } from "../../api/managementApi.js";
 import { backupStories } from "../../api/stories/backup.js";
 import { parsePublishLanguagesOption } from "../../api/stories/stories.js";
-import { createAndSaveToFile } from "../../utils/files.js";
 import Logger from "../../utils/logger.js";
 import { apiConfig } from "../api-config.js";
 import { askForConfirmation } from "../helpers.js";
@@ -411,21 +409,8 @@ export const migrate = async (props: CLIOptions) => {
                 const runMigration = async () => {
                     Logger.warning("Preparing to migrate...");
 
-                    if (!dryRun) {
-                        const response =
-                            await managementApi.presets.getAllPresets(
-                                apiConfig,
-                            );
-
-                        await createAndSaveToFile(
-                            {
-                                filename: "presets-backup",
-                                res: response,
-                            },
-                            apiConfig,
-                        );
-                    }
-
+                    // The pre-migration backup is made by the engine, which
+                    // backs up the actual `from` items into backup/preset.
                     await migrateAllComponentsDataInStories(
                         {
                             itemType: "preset",


### PR DESCRIPTION
Implements [DT-319](https://centralcreativestudio.atlassian.net/browse/DT-319) via its six split GCTT tickets. Scope is `sb-mig migrate presets` command parity with `migrate content` only — migrating presets by default alongside content/component sync is explicitly out of scope and untouched.

Docs for this land separately in sb-mig-landing#11.

| Commit | Ticket | What |
| --- | --- | --- |
| `892b8ba` | GCTT-3841 | Baseline test coverage for preset migrations (landed first, as the safety net) |
| `22d163f` | GCTT-3837 | Support multiple `--migration` values for presets |
| `2ac321a` | GCTT-3839 | Stop recording publication metadata for preset runs |
| `55d2e90` | GCTT-3840 | Drop the duplicate CLI-level preset backup |
| `299c181` | GCTT-3838 | Support scoped component runs for presets |
| `4459be0` | GCTT-3842 | Reject cross-space preset runs |
| `3895ff7` | GCTT-3838 | Follow-up: make the scoped run actually reachable from the built CLI |
| `0a820d4` | — | Mark the "presets deferred" decision in `docs/migrate-continue.md` as superseded |

## What changed

**Multi-step pipelines (GCTT-3837).** The presets CLI branch rejected more than one `--migration` and passed only `migrationConfigs[0]` to the engine, even though the engine has always run multi-step pipelines identically for `story` and `preset`. Guard removed, full array passed, help text updated.

**Scoped runs (GCTT-3838).** `migrate presets <component...>` now works, narrowing the migration's mappers to the named components.

**Publication metadata (GCTT-3839).** `doTheMigration` defaulted `publicationMode` to `preserve-layers` and computed publication languages even for presets, so a preset dry-run stamped its continue manifest with `preserve-layers` / `publishLanguages: "all"` and `migrate continue` echoed both — for a run that cannot publish anything. Now normalized to `save-only` at the top of `doTheMigration`, which makes the manifest agree with what `savePipelineSummary` already recorded. Progress messages are itemType-aware.

**Duplicate backup (GCTT-3840).** The presets branch backed up presets itself using `apiConfig`'s default space rather than `--from`, so a run with `--from` pointing elsewhere backed up the wrong space — and it ran even for `--migrate-from file`. The engine already backs up the actual `from` items into `backup/preset`, which is what `migrate content` relies on. CLI backup removed.

**Cross-space guard (GCTT-3842).** `updatePreset` PUTs to `spaces/<to>/presets/<id>` reusing the id the preset has in the *source* space, so `--from A --to B` either failed on ids that don't exist in B or silently overwrote unrelated presets there. Now a hard error on both preset paths.

## Please read this bit: the `isIt("empty")` trap

`3895ff7` fixes a bug in `299c181` in this same PR. Worth understanding, because the same trap is still live elsewhere in the CLI.

`--migrate-from` is declared with `default: "space", isRequired: true` (`src/cli/index.ts:67`), so meow puts `migrateFrom` into `flags` on **every** invocation. `isItFactory` requires every present flag key to be either whitelisted or consumed by the rule, and `migrateFrom` is neither for the `empty` rule — so `isIt("empty")` can never be true from the built CLI. The scoped preset path added in `299c181` was therefore dead code: `sb-mig migrate presets text-block --migration x` fell through to "Wrong combination of flags."

It passed CI because the CLI test hand-built a flags object without `migrateFrom` — a fixture that doesn't match what meow produces. The assertions were fine; the input was fiction.

The presets branch now routes on what was actually typed (`!flags["all"] && components.length > 0`), and the test helper injects `migrateFrom: "space"` the way meow does, so every scoped test now exercises real routing. Verified against the **built** CLI this time, not just the unit harness:

```
migrate presets text-block --from 12345 --to 12345 --migration nope --dry-run
  → reaches "Preparing to migrate...", fails on the bogus migration name (correct)
migrate presets --all ...                    → same, --all path intact
migrate presets --all --from 12345 --to 67890 --yes    → cross-space guard fires
migrate presets text-block --from 12345 --to 67890 --yes → cross-space guard fires
```

**`migrate content <component...>` has the identical defect and is NOT fixed here.** It's pre-existing, already documented with an `--all --migrationComponents` workaround, and fixing it changes stories routing — out of scope for these tickets. Worth its own ticket if you want it.

## Other decisions worth a look

**The cross-space guard exempts `--migrate-from file` runs.** With `--migrate-from file`, `from` is a file name derived from `path.parse(fromFilePath).name`, not a space — an unconditional `from !== to` check would reject the documented restore-from-backup command. Residual risk: a preset file captured from a *different* space has the same wrong-id problem, and sb-mig has no way to know which space a file came from. Left unguarded rather than guessed at; stamping the source space into preset backup files would make it detectable, if that turns out to matter.

**The optional `component_id` fetch filter in GCTT-3838 was not implemented.** Presets carry a numeric `component_id` but `componentsToMigrate` holds component *names*, so filtering the fetch needs a components lookup to build a name→id map. It's a fetch-efficiency gain, not a correctness one — the acceptance criterion is already met by the mapper scope, which makes the migration a no-op for every other preset.

## Testing

Preset migrations went from **zero** coverage (`itemType: "preset"` appeared only as a mock stub) to 35 tests:

- `__tests__/api/preset-data-migration.test.ts` — engine level: pipeline transforms over the raw `{id, name, component_id, preset}` shape, nested components, scoped runs, multi-step pipelines with per-step validators, the `updatePresets` write path with no publish options, the pre-migration backup, and the dry-run → `migrate continue` round trip.
- `__tests__/cli/migrate-presets.test.ts` — CLI level: drives the real `migrate` command with a mocked engine to pin flag wiring, routing, the backup removal, and the cross-space guard.

`npm run test:unit` → 57 files / 584 tests passing. `npm run build` clean. Rebased onto current `beta` (`ef4801c`) with no conflicts.

Note: the full `npm run test` also runs `__tests__/api-live/*.live.test.ts`, which fail without live Storyblok credentials. That is pre-existing on `beta` and unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
