### PR TITLE
fix(migrate): stop meow's migrateFrom default from killing the scoped rule (GCTT-3879)

### DIFF
--- a/__tests__/cli/cli-utils.test.ts
+++ b/__tests__/cli/cli-utils.test.ts
@@ -177,6 +177,37 @@ describe("isItFactory - flag matching", () => {
         expect(isIt("allWithSSOT")).toBe(false);
     });
 
+    // meow emits a key for every flag declared with `default:` or
+    // `isMultiple: true`, whether or not the user typed it. Such a flag has to
+    // be handled explicitly or it silently defeats the rule — this is what made
+    // `migrate content <component...>` unreachable (GCTT-3879).
+    describe("flags meow always injects", () => {
+        const meowRules = { empty: [], withDefault: ["migrateFrom"] };
+
+        it("kills a rule that neither whitelists nor consumes the injected flag", () => {
+            const flags = { migrateFrom: "space", from: "12345" };
+            const isIt = isItFactory(flags, meowRules, ["from"]);
+
+            expect(isIt("empty")).toBe(false);
+        });
+
+        it("matches once the rule consumes the injected flag", () => {
+            const flags = { migrateFrom: "space", from: "12345" };
+            const isIt = isItFactory(flags, meowRules, ["from"]);
+
+            expect(isIt("withDefault")).toBe(true);
+        });
+
+        it("cannot be solved by whitelisting when another rule requires the flag", () => {
+            const flags = { migrateFrom: "space" };
+            const isIt = isItFactory(flags, meowRules, ["migrateFrom"]);
+
+            // The whitelist is checked before the rule, so the rule's
+            // requirement is never satisfied and it can never match.
+            expect(isIt("withDefault")).toBe(false);
+        });
+    });
+
     it("should handle SSOT flag", () => {
         const flags = { all: true, ssot: true };
         const isIt = isItFactory(flags, rules, []);

--- a/__tests__/cli/migrate-content.test.ts
+++ b/__tests__/cli/migrate-content.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    migrateAllComponentsDataInStories: vi.fn(),
+    migrateProvidedComponentsDataInStories: vi.fn(),
+    prepareContinueMigration: vi.fn(),
+    backupStories: vi.fn(),
+}));
+
+vi.mock("../../src/cli/api-config.js", () => ({
+    apiConfig: {
+        spaceId: "default-space",
+        sbApi: {},
+    },
+}));
+
+vi.mock("../../src/api/data-migration/component-data-migration.js", () => ({
+    migrateAllComponentsDataInStories: mocks.migrateAllComponentsDataInStories,
+    migrateProvidedComponentsDataInStories:
+        mocks.migrateProvidedComponentsDataInStories,
+    prepareContinueMigration: mocks.prepareContinueMigration,
+}));
+
+vi.mock("../../src/api/stories/backup.js", () => ({
+    backupStories: mocks.backupStories,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+    default: {
+        log: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+import { migrate } from "../../src/cli/commands/migrate.js";
+
+/**
+ * What `meow` actually hands the command. Every flag declared with `default:`
+ * or `isMultiple: true` is present on every invocation, typed or not —
+ * confirmed by dumping the flags object from the built CLI. Tests that omit
+ * these do not exercise the routing the CLI really performs (GCTT-3879).
+ */
+const cliFlags = (overrides: Record<string, unknown>) => ({
+    migrateFrom: "space",
+    migration: [] as string[],
+    migrationComponentAlias: [] as string[],
+    migrationComponents: [] as string[],
+    withSlug: [] as string[],
+    dryRun: false,
+    ...overrides,
+});
+
+const runMigrateContent = (
+    components: string[],
+    flags: Record<string, unknown>,
+) =>
+    migrate({
+        input: ["migrate", "content", ...components],
+        flags: cliFlags(flags),
+    } as any);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.migrateAllComponentsDataInStories.mockResolvedValue(undefined);
+    mocks.migrateProvidedComponentsDataInStories.mockResolvedValue(undefined);
+    mocks.backupStories.mockResolvedValue(undefined);
+});
+
+describe("migrate content <component...> (scoped run)", () => {
+    it("reaches the engine with the named components", async () => {
+        await runMigrateContent(["my-component-1", "my-component-2"], {
+            from: "12345",
+            to: "12345",
+            migration: ["migration-a"],
+            dryRun: true,
+        });
+
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).toHaveBeenCalledTimes(1);
+        const [engineArgs] =
+            mocks.migrateProvidedComponentsDataInStories.mock.calls[0];
+        expect(engineArgs.itemType).toBe("story");
+        expect(engineArgs.componentsToMigrate).toEqual([
+            "my-component-1",
+            "my-component-2",
+        ]);
+        expect(engineArgs.migrationConfig).toEqual(["migration-a"]);
+        expect(engineArgs.migrateFrom).toBe("space");
+        expect(mocks.migrateAllComponentsDataInStories).not.toHaveBeenCalled();
+    });
+
+    it("is not defeated by the migrateFrom default meow always injects", async () => {
+        // Regression for GCTT-3879: `migrateFrom` is present on every real
+        // invocation, and the `empty` rule used to ignore it, which made this
+        // whole command form unreachable from the built CLI.
+        await runMigrateContent(["my-component-1"], {
+            migrateFrom: "space",
+            from: "12345",
+            to: "12345",
+            migration: ["migration-a"],
+            dryRun: true,
+        });
+
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).toHaveBeenCalledTimes(1);
+    });
+
+    it("takes a story backup on a real scoped run", async () => {
+        await runMigrateContent(["my-component-1"], {
+            from: "12345",
+            to: "12345",
+            migration: ["migration-a"],
+            yes: true,
+        });
+
+        expect(mocks.backupStories).toHaveBeenCalledTimes(1);
+        const [backupArgs] = mocks.backupStories.mock.calls[0];
+        expect(backupArgs.spaceId).toBe("12345");
+    });
+
+    it("rejects a cross-space scoped run under the default publication mode", async () => {
+        await expect(
+            runMigrateContent(["my-component-1"], {
+                from: "12345",
+                to: "67890",
+                migration: ["migration-a"],
+                dryRun: true,
+            }),
+        ).rejects.toThrow("preserve-layers");
+
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).not.toHaveBeenCalled();
+    });
+});
+
+describe("migrate content --all", () => {
+    it("still routes through the all-components path", async () => {
+        await runMigrateContent([], {
+            all: true,
+            from: "12345",
+            to: "12345",
+            migration: ["migration-a"],
+            dryRun: true,
+        });
+
+        expect(mocks.migrateAllComponentsDataInStories).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(
+            mocks.migrateProvidedComponentsDataInStories,
+        ).not.toHaveBeenCalled();
+    });
+
+    it("requires at least one --migration value", async () => {
+        await expect(
+            runMigrateContent([], {
+                all: true,
+                from: "12345",
+                to: "12345",
+                dryRun: true,
+            }),
+        ).rejects.toThrow("Pass at least one --migration value");
+    });
+});

--- a/__tests__/cli/migrate-presets.test.ts
+++ b/__tests__/cli/migrate-presets.test.ts
@@ -46,10 +46,26 @@ vi.mock("../../src/utils/logger.js", () => ({
 
 import { migrate } from "../../src/cli/commands/migrate.js";
 
+/**
+ * What `meow` actually hands the command. Every flag declared with `default:`
+ * or `isMultiple: true` is present on every invocation, typed or not. Tests
+ * that omit these do not exercise the routing the CLI really performs — that
+ * is how the scoped form shipped dead in v6.5.0-beta.2 (GCTT-3879).
+ */
+const cliFlags = (overrides: Record<string, unknown>) => ({
+    migrateFrom: "space",
+    migration: [] as string[],
+    migrationComponentAlias: [] as string[],
+    migrationComponents: [] as string[],
+    withSlug: [] as string[],
+    dryRun: false,
+    ...overrides,
+});
+
 const runMigratePresets = (flags: Record<string, unknown>) =>
     migrate({
         input: ["migrate", "presets"],
-        flags,
+        flags: cliFlags(flags),
     } as any);
 
 beforeEach(() => {
@@ -117,7 +133,7 @@ describe("migrate presets <component...> (scoped run)", () => {
     const runScoped = (components: string[], flags: Record<string, unknown>) =>
         migrate({
             input: ["migrate", "presets", ...components],
-            flags,
+            flags: cliFlags(flags),
         } as any);
 
     it("scopes the migration to the provided component names", async () => {
@@ -269,12 +285,12 @@ describe("migrate presets cross-space guard", () => {
         await expect(
             migrate({
                 input: ["migrate", "presets", "text-block"],
-                flags: {
+                flags: cliFlags({
                     from: "12345",
                     to: "67890",
                     migration: "migration-a",
                     yes: true,
-                },
+                }),
             } as any),
         ).rejects.toThrow("the same Storyblok space");
 

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -116,8 +116,15 @@ export const migrate = async (props: CLIOptions) => {
     const { input, flags } = props;
 
     const command = input[1];
+    // `empty` (the scoped `migrate <command> <component...>` form) has to
+    // consume `migrateFrom`: it is declared with a default, so meow puts it in
+    // `flags` on every invocation. A rule only matches when every present flag
+    // is either whitelisted or consumed by the rule, so leaving it out here
+    // made `isIt("empty")` unconditionally false and the scoped form dead.
+    // It cannot be whitelisted instead — `all` requires it, and the whitelist
+    // is checked first, which would stop `all` from ever matching.
     const rules = {
-        empty: [],
+        empty: ["migrateFrom"],
         all: ["all", "migrateFrom"],
     };
     const isIt = isItFactory<keyof typeof rules>(flags, rules, [


### PR DESCRIPTION
Fixes [GCTT-3879](https://centralcreativestudio.atlassian.net/browse/GCTT-3879). One-line behavioural change; the rest is tests.

## The bug

`sb-mig migrate content my-component --migration x` — a form listed in `migrate --help` and on the docs site — exits with `Wrong combination of flags` and does nothing.

## Root cause

`isItFactory` matches a rule only when **every** key present in `flags` is either whitelisted or consumed by the rule. meow emits a key for every flag declared with `default:` or `isMultiple: true`, typed or not. Dumped from the built CLI:

```
$ sb-mig migrate presets --migration nope
Passed flags:
{ migration: [ 'nope' ], migrateFrom: 'space', migrationComponentAlias: [],
  migrationComponents: [], withSlug: [], dryRun: false }
```

The migrate whitelist covers `migration`, `migrationComponentAlias`, `migrationComponents`, `withSlug` and `dryRun` — but not `migrateFrom`. With `rules.empty = []`, `migrateFrom` matched neither, so `isIt("empty")` was **unconditionally false** and the entire scoped branch was dead code.

## The fix

```diff
-    empty: [],
+    empty: ["migrateFrom"],
```

It cannot be solved by whitelisting `migrateFrom` instead: `rules.all` requires it, and the whitelist is checked *before* the rule, so whitelisting would stop `--all` from ever matching. There's a test pinning that.

Verified against the built CLI, before and after:

| Command | `beta` | this PR |
| --- | --- | --- |
| `migrate content my-comp --migration …` | ✘ rejected | routes to engine |
| `migrate content --all` | routes to engine | routes to engine |
| `migrate presets text-block --migration …` | ✘ rejected | routes to engine |
| `migrate presets --all` | routes to engine | routes to engine |

## This supersedes #393 — suggest closing it

#393 fixes the *preset* half of this by routing on typed input instead of `isIt("empty")`. This PR fixes the shared root cause, so **both** command forms work with one line and no per-command special-casing. Row 3 of that table is on this branch, with no preset-specific code.

My suggestion: close #393 unmerged and take this instead. Its only other content — the `docs/migrate-continue.md` D-3 note — I'd re-land separately. Happy to do it the other way round if you prefer the explicit routing; they don't conflict textually, they'd just be redundant.

GCTT-3851 (the preset-specific bug) is then resolved by this PR too.

## Why CI never caught it

The CLI tests hand-built their `flags` object without the injected defaults — a fixture that doesn't match what meow produces. Green tests, dead feature. Both migrate test files now build flags from a documented `cliFlags()` helper that mirrors meow, so the fixtures can't drift back into fiction.

Note the 4 pre-existing `migrate-presets` tests that **started failing** when the rule was fixed: they asserted a scoped run worked while passing flags the CLI never sends. That's the bug reproducing itself in the test suite.

## Blast radius

Each command has its own `meow()` instance, so only a command's own defaulted flags can defeat its rules. Of the `isItFactory` consumers — `migrate`, `sync`, `backup`, `revert`, `migrations` — only `migrate` declares defaulted or `isMultiple` flags. The others are unaffected.

**Deliberately not done:** reordering `isItFactory` to check rules before the whitelist. That looks like the "real" general fix, but `sync`'s whitelist contains `presets` while `rules.allWithPresets`/`onlyPresets` require it, so both are currently unreachable — and `sync`'s `all`/`empty` branches read `flags["presets"]` directly (`sync.ts:69,86`), so preset syncing works today. Reordering would activate two dead rules and reroute a working, heavily used command. Those dead rules are worth deleting in a separate cleanup; see the ticket.

## Checks

`npm run test:unit` → 58 files / 592 tests. `npm run build` clean. Branched off current `beta` (`28d00d6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
